### PR TITLE
Update the text domain for the translated text strings

### DIFF
--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -77,7 +77,7 @@ class WC_API extends WC_Legacy_API {
 	 */
 	public function get_endpoint_data( $endpoint, $params = array() ) {
 		if ( ! $this->is_rest_api_loaded() ) {
-			return new WP_Error( 'rest_api_unavailable', __( 'The Rest API is unavailable.', 'woocommerce' ) );
+			return new WP_Error( 'rest_api_unavailable', __( 'The Rest API is unavailable.', 'woocommerce-legacy-rest-api' ) );
 		}
 		$request = new \WP_REST_Request( 'GET', $endpoint );
 		if ( $params ) {

--- a/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
@@ -110,7 +110,7 @@ class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {
 		// Validate required POST fields.
 		if ( 'POST' === $request->get_method() && 0 === $coupon->get_id() ) {
 			if ( empty( $request['code'] ) ) {
-				return new WP_Error( 'woocommerce_rest_empty_coupon_code', sprintf( __( 'The coupon code cannot be empty.', 'woocommerce' ), 'code' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_rest_empty_coupon_code', sprintf( __( 'The coupon code cannot be empty.', 'woocommerce-legacy-rest-api' ), 'code' ), array( 'status' => 400 ) );
 			}
 		}
 
@@ -126,7 +126,7 @@ class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {
 						$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 						if ( $id_from_code ) {
-							return new WP_Error( 'woocommerce_rest_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), array( 'status' => 400 ) );
+							return new WP_Error( 'woocommerce_rest_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce-legacy-rest-api' ), array( 'status' => 400 ) );
 						}
 
 						$coupon->set_code( $coupon_code );

--- a/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
@@ -246,7 +246,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 		try {
 			// Make sure customer exists.
 			if ( ! is_null( $request['customer_id'] ) && 0 !== $request['customer_id'] && false === get_user_by( 'id', $request['customer_id'] ) ) {
-				throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id',__( 'Customer ID is invalid.', 'woocommerce' ), 400 );
+				throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id',__( 'Customer ID is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Make sure customer is part of blog.

--- a/includes/legacy/api/class-wc-rest-legacy-products-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-products-controller.php
@@ -529,7 +529,7 @@ class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {
 			// Create initial name and status.
 			if ( ! $variation->get_slug() ) {
 				/* translators: 1: variation id 2: product name */
-				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation->get_id(), $product->get_name() ) );
+				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce-legacy-rest-api' ), $variation->get_id(), $product->get_name() ) );
 				$variation->set_status( isset( $data['visible'] ) && false === $data['visible'] ? 'private' : 'publish' );
 			}
 

--- a/includes/legacy/api/v1/class-wc-api-authentication.php
+++ b/includes/legacy/api/v1/class-wc-api-authentication.php
@@ -90,7 +90,7 @@ class WC_API_Authentication {
 
 		} else {
 
-			throw new Exception( __( 'Consumer key is missing.', 'woocommerce' ), 404 );
+			throw new Exception( __( 'Consumer key is missing.', 'woocommerce-legacy-rest-api' ), 404 );
 		}
 
 		// Get consumer secret
@@ -106,13 +106,13 @@ class WC_API_Authentication {
 
 		} else {
 
-			throw new Exception( __( 'Consumer secret is missing.', 'woocommerce' ), 404 );
+			throw new Exception( __( 'Consumer secret is missing.', 'woocommerce-legacy-rest-api' ), 404 );
 		}
 
 		$keys = $this->get_keys_by_consumer_key( $consumer_key );
 
 		if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $consumer_secret ) ) {
-			throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $keys;
@@ -146,7 +146,7 @@ class WC_API_Authentication {
 
 			if ( empty( $params[ $param_name ] ) ) {
 				/* translators: %s: parameter name */
-				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
+				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce-legacy-rest-api' ), $param_name ), 404 );
 			}
 		}
 
@@ -181,7 +181,7 @@ class WC_API_Authentication {
 		", $consumer_key ), ARRAY_A );
 
 		if ( empty( $keys ) ) {
-			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $keys;
@@ -200,7 +200,7 @@ class WC_API_Authentication {
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! $user ) {
-			throw new Exception( __( 'API user is invalid', 'woocommerce' ), 401 );
+			throw new Exception( __( 'API user is invalid', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $user;
@@ -250,7 +250,7 @@ class WC_API_Authentication {
 
 		// Sort parameters
 		if ( ! uksort( $params, 'strcmp' ) ) {
-			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		// Form query string
@@ -264,7 +264,7 @@ class WC_API_Authentication {
 		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
 
 		if ( 'HMAC-SHA1' !== $params['oauth_signature_method'] && 'HMAC-SHA256' !== $params['oauth_signature_method'] ) {
-			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
@@ -272,7 +272,7 @@ class WC_API_Authentication {
 		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $keys['consumer_secret'], true ) );
 
 		if ( ! hash_equals( $signature, $consumer_signature ) ) {
-			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 	}
 
@@ -330,7 +330,7 @@ class WC_API_Authentication {
 		$valid_window = 15 * 60; // 15 minute window
 
 		if ( ( $timestamp < time() - $valid_window ) || ( $timestamp > time() + $valid_window ) ) {
-			throw new Exception( __( 'Invalid timestamp.', 'woocommerce' ) );
+			throw new Exception( __( 'Invalid timestamp.', 'woocommerce-legacy-rest-api' ) );
 		}
 
 		$used_nonces = maybe_unserialize( $keys['nonces'] );
@@ -340,7 +340,7 @@ class WC_API_Authentication {
 		}
 
 		if ( in_array( $nonce, $used_nonces ) ) {
-			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$used_nonces[ $timestamp ] = $nonce;
@@ -375,7 +375,7 @@ class WC_API_Authentication {
 			case 'HEAD':
 			case 'GET':
 				if ( 'read' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 
@@ -384,7 +384,7 @@ class WC_API_Authentication {
 			case 'PATCH':
 			case 'DELETE':
 				if ( 'write' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 		}

--- a/includes/legacy/api/v1/class-wc-api-coupons.php
+++ b/includes/legacy/api/v1/class-wc-api-coupons.php
@@ -108,7 +108,7 @@ class WC_API_Coupons extends WC_API_Resource {
 		$coupon = new WC_Coupon( $id );
 
 		if ( 0 === $coupon->get_id() ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce-legacy-rest-api' ), 404 );
 		}
 
 		$coupon_data = array(
@@ -151,7 +151,7 @@ class WC_API_Coupons extends WC_API_Resource {
 		$query = $this->query_coupons( $filter );
 
 		if ( ! current_user_can( 'read_private_shop_coupons' ) ) {
-			return new WP_Error( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 		}
 
 		return array( 'count' => (int) $query->found_posts );
@@ -171,7 +171,7 @@ class WC_API_Coupons extends WC_API_Resource {
 		$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 1;", $code ) );
 
 		if ( is_null( $id ) ) {
-			return new WP_Error( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 		}
 
 		return $this->get_coupon( $id, $fields );

--- a/includes/legacy/api/v1/class-wc-api-customers.php
+++ b/includes/legacy/api/v1/class-wc-api-customers.php
@@ -183,7 +183,7 @@ class WC_API_Customers extends WC_API_Resource {
 		$query = $this->query_customers( $filter );
 
 		if ( ! current_user_can( 'list_users' ) ) {
-			return new WP_Error( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 		}
 
 		return array( 'count' => count( $query->get_results() ) );
@@ -199,7 +199,7 @@ class WC_API_Customers extends WC_API_Resource {
 	public function create_customer( $data ) {
 
 		if ( ! current_user_can( 'create_users' ) ) {
-			return new WP_Error( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 		}
 
 		return array();
@@ -431,14 +431,14 @@ class WC_API_Customers extends WC_API_Resource {
 
 		// validate ID
 		if ( empty( $id ) ) {
-			return new WP_Error( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 		}
 
 		// non-existent IDs return a valid WP_User object with the user ID = 0
 		$customer = new WP_User( $id );
 
 		if ( 0 === $customer->ID ) {
-			return new WP_Error( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 		}
 
 		// validate permissions
@@ -446,19 +446,19 @@ class WC_API_Customers extends WC_API_Resource {
 
 			case 'read':
 				if ( ! current_user_can( 'list_users' ) ) {
-					return new WP_Error( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), array( 'status' => 401 ) );
+					return new WP_Error( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'edit':
 				if ( ! current_user_can( 'edit_users' ) ) {
-					return new WP_Error( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), array( 'status' => 401 ) );
+					return new WP_Error( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'delete':
 				if ( ! current_user_can( 'delete_users' ) ) {
-					return new WP_Error( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), array( 'status' => 401 ) );
+					return new WP_Error( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 				}
 				break;
 		}

--- a/includes/legacy/api/v1/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v1/class-wc-api-json-handler.php
@@ -52,14 +52,14 @@ class WC_API_JSON_Handler implements WC_API_Handler {
 
 			if ( ! apply_filters( 'woocommerce_api_jsonp_enabled', true ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			$jsonp_callback = $_GET['_jsonp'];
 
 			if ( ! wp_check_jsonp_callback( $jsonp_callback ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			WC()->api->server->header( 'X-Content-Type-Options', 'nosniff' );

--- a/includes/legacy/api/v1/class-wc-api-orders.php
+++ b/includes/legacy/api/v1/class-wc-api-orders.php
@@ -252,7 +252,7 @@ class WC_API_Orders extends WC_API_Resource {
 		$query = $this->query_orders( $filter );
 
 		if ( ! current_user_can( 'read_private_shop_orders' ) ) {
-			return new WP_Error( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 		}
 
 		return array( 'count' => (int) $query->found_posts );

--- a/includes/legacy/api/v1/class-wc-api-products.php
+++ b/includes/legacy/api/v1/class-wc-api-products.php
@@ -144,7 +144,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		if ( ! current_user_can( 'read_private_products' ) ) {
-			return new WP_Error( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 		}
 
 		$query = $this->query_products( $filter );
@@ -456,8 +456,8 @@ class WC_API_Products extends WC_API_Resource {
 				'created_at' => $this->server->format_datetime( time() ), // default to now
 				'updated_at' => $this->server->format_datetime( time() ),
 				'src'        => wc_placeholder_img_src(),
-				'title'      => __( 'Placeholder', 'woocommerce' ),
-				'alt'        => __( 'Placeholder', 'woocommerce' ),
+				'title'      => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
+				'alt'        => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
 				'position'   => 0,
 			);
 		}

--- a/includes/legacy/api/v1/class-wc-api-reports.php
+++ b/includes/legacy/api/v1/class-wc-api-reports.php
@@ -472,7 +472,7 @@ class WC_API_Reports extends WC_API_Resource {
 
 		if ( ! current_user_can( 'view_woocommerce_reports' ) ) {
 
-			return new WP_Error( 'woocommerce_api_user_cannot_read_report', __( 'You do not have permission to read this report', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_report', __( 'You do not have permission to read this report', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 
 		} else {
 

--- a/includes/legacy/api/v1/class-wc-api-resource.php
+++ b/includes/legacy/api/v1/class-wc-api-resource.php
@@ -71,7 +71,7 @@ class WC_API_Resource {
 
 		// validate ID
 		if ( empty( $id ) ) {
-			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce-legacy-rest-api' ), $type ), array( 'status' => 404 ) );
 		}
 
 		// only custom post types have per-post type/permission checks
@@ -84,7 +84,7 @@ class WC_API_Resource {
 
 			// validate post type
 			if ( $type !== $post_type ) {
-				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce' ), $resource_name ), array( 'status' => 404 ) );
+				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 404 ) );
 			}
 
 			// validate permissions
@@ -92,19 +92,19 @@ class WC_API_Resource {
 
 				case 'read':
 					if ( ! $this->is_readable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 
 				case 'edit':
 					if ( ! $this->is_editable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 
 				case 'delete':
 					if ( ! $this->is_deletable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 			}
@@ -310,9 +310,9 @@ class WC_API_Resource {
 			$result = wp_delete_user( $id );
 
 			if ( $result ) {
-				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
+				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce-legacy-rest-api' ) );
 			} else {
-				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 			}
 		} else {
 
@@ -320,17 +320,17 @@ class WC_API_Resource {
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 
 			if ( ! $result ) {
-				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 500 ) );
 			}
 
 			if ( $force ) {
-				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 
 			} else {
 
 				$this->server->send_status( '202' );
 
-				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 			}
 		}
 	}

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -165,7 +165,7 @@ class WC_API_Server {
 			wp_set_current_user( $user->ID );
 		} elseif ( ! is_wp_error( $user ) ) {
 			// WP_Errors are handled in serve_request()
-			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce' ), array( 'code' => 500 ) );
+			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce-legacy-rest-api' ), array( 'code' => 500 ) );
 		}
 
 		return $user;
@@ -318,7 +318,7 @@ class WC_API_Server {
 				break;
 
 			default:
-				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 400 ) );
 		}
 
 		foreach ( $this->get_routes() as $route => $handlers ) {
@@ -337,7 +337,7 @@ class WC_API_Server {
 				}
 
 				if ( ! is_callable( $callback ) ) {
-					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce' ), array( 'status' => 500 ) );
+					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 				}
 
 				$args = array_merge( $args, $this->params['GET'] );
@@ -374,7 +374,7 @@ class WC_API_Server {
 			}
 		}
 
-		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce' ), array( 'status' => 404 ) );
+		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 	}
 
 	/**
@@ -409,7 +409,7 @@ class WC_API_Server {
 				$ordered_parameters[] = $param->getDefaultValue();
 			} else {
 				// We don't have this parameter and it wasn't optional, abort!
-				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param->getName() ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), $param->getName() ), array( 'status' => 400 ) );
 			}
 		}
 		return $ordered_parameters;

--- a/includes/legacy/api/v2/class-wc-api-authentication.php
+++ b/includes/legacy/api/v2/class-wc-api-authentication.php
@@ -89,7 +89,7 @@ class WC_API_Authentication {
 
 		} else {
 
-			throw new Exception( __( 'Consumer key is missing.', 'woocommerce' ), 404 );
+			throw new Exception( __( 'Consumer key is missing.', 'woocommerce-legacy-rest-api' ), 404 );
 		}
 
 		// Get consumer secret
@@ -105,13 +105,13 @@ class WC_API_Authentication {
 
 		} else {
 
-			throw new Exception( __( 'Consumer secret is missing.', 'woocommerce' ), 404 );
+			throw new Exception( __( 'Consumer secret is missing.', 'woocommerce-legacy-rest-api' ), 404 );
 		}
 
 		$keys = $this->get_keys_by_consumer_key( $consumer_key );
 
 		if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $consumer_secret ) ) {
-			throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $keys;
@@ -144,7 +144,7 @@ class WC_API_Authentication {
 		foreach ( $param_names as $param_name ) {
 
 			if ( empty( $params[ $param_name ] ) ) {
-				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
+				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce-legacy-rest-api' ), $param_name ), 404 );
 			}
 		}
 
@@ -179,7 +179,7 @@ class WC_API_Authentication {
 		", $consumer_key ), ARRAY_A );
 
 		if ( empty( $keys ) ) {
-			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $keys;
@@ -197,7 +197,7 @@ class WC_API_Authentication {
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! $user ) {
-			throw new Exception( __( 'API user is invalid', 'woocommerce' ), 401 );
+			throw new Exception( __( 'API user is invalid', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $user;
@@ -247,7 +247,7 @@ class WC_API_Authentication {
 
 		// Sort parameters
 		if ( ! uksort( $params, 'strcmp' ) ) {
-			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		// Form query string
@@ -261,7 +261,7 @@ class WC_API_Authentication {
 		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
 
 		if ( 'HMAC-SHA1' !== $params['oauth_signature_method'] && 'HMAC-SHA256' !== $params['oauth_signature_method'] ) {
-			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
@@ -269,7 +269,7 @@ class WC_API_Authentication {
 		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $keys['consumer_secret'], true ) );
 
 		if ( ! hash_equals( $signature, $consumer_signature ) ) {
-			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 	}
 
@@ -327,7 +327,7 @@ class WC_API_Authentication {
 		$valid_window = 15 * 60; // 15 minute window
 
 		if ( ( $timestamp < time() - $valid_window ) || ( $timestamp > time() + $valid_window ) ) {
-			throw new Exception( __( 'Invalid timestamp.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid timestamp.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$used_nonces = maybe_unserialize( $keys['nonces'] );
@@ -337,7 +337,7 @@ class WC_API_Authentication {
 		}
 
 		if ( in_array( $nonce, $used_nonces ) ) {
-			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$used_nonces[ $timestamp ] = $nonce;
@@ -372,7 +372,7 @@ class WC_API_Authentication {
 			case 'HEAD':
 			case 'GET':
 				if ( 'read' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 
@@ -381,7 +381,7 @@ class WC_API_Authentication {
 			case 'PATCH':
 			case 'DELETE':
 				if ( 'write' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 		}

--- a/includes/legacy/api/v2/class-wc-api-coupons.php
+++ b/includes/legacy/api/v2/class-wc-api-coupons.php
@@ -114,7 +114,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			$coupon = new WC_Coupon( $id );
 
 			if ( 0 === $coupon->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$coupon_data = array(
@@ -160,7 +160,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	public function get_coupons_count( $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'read_private_shop_coupons' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$query = $this->query_coupons( $filter );
@@ -186,7 +186,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 1;", $code ) );
 
 			if ( is_null( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			return $this->get_coupon( $id, $fields );
@@ -209,28 +209,28 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupon'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'coupon' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'coupon' ), 400 );
 			}
 
 			$data = $data['coupon'];
 
 			// Check user permission
 			if ( ! current_user_can( 'publish_shop_coupons' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_coupon', __( 'You do not have permission to create coupons', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_coupon', __( 'You do not have permission to create coupons', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_coupon_data', $data, $this );
 
 			// Check if coupon code is specified
 			if ( ! isset( $data['code'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_code', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'code' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_code', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'code' ), 400 );
 			}
 
 			$coupon_code  = wc_format_coupon_code( $data['code'] );
 			$id_from_code = wc_get_coupon_id_by_code( $coupon_code );
 
 			if ( $id_from_code ) {
-				throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$defaults = array(
@@ -258,7 +258,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 			// Validate coupon types
 			if ( ! in_array( wc_clean( $coupon_data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
 			}
 
 			$new_coupon = array(
@@ -321,7 +321,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupon'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'coupon' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'coupon' ), 400 );
 			}
 
 			$data = $data['coupon'];
@@ -341,13 +341,13 @@ class WC_API_Coupons extends WC_API_Resource {
 				$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 				if ( $id_from_code ) {
-					throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$updated = wp_update_post( array( 'ID' => intval( $id ), 'post_title' => $coupon_code ) );
 
 				if ( 0 === $updated ) {
-					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -355,14 +355,14 @@ class WC_API_Coupons extends WC_API_Resource {
 				$updated = wp_update_post( array( 'ID' => intval( $id ), 'post_excerpt' => $data['description'] ) );
 
 				if ( 0 === $updated ) {
-					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
 			if ( isset( $data['type'] ) ) {
 				// Validate coupon types
 				if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
 				}
 				update_post_meta( $id, 'discount_type', $data['type'] );
 			}
@@ -518,7 +518,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupons'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupons_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'coupons' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupons_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'coupons' ), 400 );
 			}
 
 			$data  = $data['coupons'];
@@ -526,7 +526,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_coupons_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_coupons_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$coupons = array();

--- a/includes/legacy/api/v2/class-wc-api-customers.php
+++ b/includes/legacy/api/v2/class-wc-api-customers.php
@@ -204,10 +204,10 @@ class WC_API_Customers extends WC_API_Resource {
 			if ( is_email( $email ) ) {
 				$customer = get_user_by( 'email', $email );
 				if ( ! is_object( $customer ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce' ), 404 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce-legacy-rest-api' ), 404 );
 				}
 			} else {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			return $this->get_customer( $customer->ID, $fields );
@@ -228,7 +228,7 @@ class WC_API_Customers extends WC_API_Resource {
 	public function get_customers_count( $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'list_users' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$query = $this->query_customers( $filter );
@@ -346,21 +346,21 @@ class WC_API_Customers extends WC_API_Resource {
 	public function create_customer( $data ) {
 		try {
 			if ( ! isset( $data['customer'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'customer' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'customer' ), 400 );
 			}
 
 			$data = $data['customer'];
 
 			// Checks with can create new users.
 			if ( ! current_user_can( 'create_users' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_customer_data', $data, $this );
 
 			// Checks with the email is missing.
 			if ( ! isset( $data['email'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_email', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'email' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_email', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'email' ), 400 );
 			}
 
 			// Create customer.
@@ -371,7 +371,7 @@ class WC_API_Customers extends WC_API_Resource {
 			$customer->save();
 
 			if ( ! $customer->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'This resource cannot be created.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'This resource cannot be created.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Added customer data.
@@ -401,7 +401,7 @@ class WC_API_Customers extends WC_API_Resource {
 	public function edit_customer( $id, $data ) {
 		try {
 			if ( ! isset( $data['customer'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'customer' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'customer' ), 400 );
 			}
 
 			$data = $data['customer'];
@@ -716,14 +716,14 @@ class WC_API_Customers extends WC_API_Resource {
 
 			// validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// non-existent IDs return a valid WP_User object with the user ID = 0
 			$customer = new WP_User( $id );
 
 			if ( 0 === $customer->ID ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// validate permissions
@@ -731,19 +731,19 @@ class WC_API_Customers extends WC_API_Resource {
 
 				case 'read':
 					if ( ! current_user_can( 'list_users' ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 
 				case 'edit':
 					if ( ! wc_rest_check_user_permissions( 'edit', $customer->ID ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 
 				case 'delete':
 					if ( ! wc_rest_check_user_permissions( 'delete', $customer->ID ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 			}
@@ -781,7 +781,7 @@ class WC_API_Customers extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['customers'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customers_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'customers' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customers_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'customers' ), 400 );
 			}
 
 			$data  = $data['customers'];
@@ -789,7 +789,7 @@ class WC_API_Customers extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_customers_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_customers_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$customers = array();

--- a/includes/legacy/api/v2/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v2/class-wc-api-json-handler.php
@@ -51,14 +51,14 @@ class WC_API_JSON_Handler implements WC_API_Handler {
 
 			if ( ! apply_filters( 'woocommerce_api_jsonp_enabled', true ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			$jsonp_callback = $_GET['_jsonp'];
 
 			if ( ! wp_check_jsonp_callback( $jsonp_callback ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			WC()->api->server->header( 'X-Content-Type-Options', 'nosniff' );

--- a/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/includes/legacy/api/v2/class-wc-api-orders.php
@@ -296,7 +296,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! current_user_can( 'read_private_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $status ) ) {
@@ -362,14 +362,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['order'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order' ), 400 );
 			}
 
 			$data = $data['order'];
 
 			// permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order', __( 'You do not have permission to create orders', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order', __( 'You do not have permission to create orders', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_order_data', $data, $this );
@@ -385,7 +385,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 				// make sure customer exists
 				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$default_order_args['customer_id'] = $data['customer_id'];
@@ -395,7 +395,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$order = $this->create_base_order( $default_order_args, $data );
 
 			if ( is_wp_error( $order ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce' ), implode( ', ', $order->get_error_messages() ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', $order->get_error_messages() ) ), 400 );
 			}
 
 			// billing/shipping addresses
@@ -429,7 +429,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 				// method ID & title are required
 				if ( empty( $data['payment_details']['method_id'] ) || empty( $data['payment_details']['method_title'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_payment_details', __( 'Payment method ID and title are required', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_payment_details', __( 'Payment method ID and title are required', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_payment_method', $data['payment_details']['method_id'] );
@@ -445,7 +445,7 @@ class WC_API_Orders extends WC_API_Resource {
 			if ( isset( $data['currency'] ) ) {
 
 				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_order_currency', $data['currency'] );
@@ -501,7 +501,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order( $id, $data ) {
 		try {
 			if ( ! isset( $data['order'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order' ), 400 );
 			}
 
 			$data = $data['order'];
@@ -518,7 +518,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$order = wc_get_order( $id );
 
 			if ( empty( $order ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$order_args = array( 'order_id' => $order->get_id() );
@@ -532,7 +532,7 @@ class WC_API_Orders extends WC_API_Resource {
 			if ( isset( $data['customer_id'] ) && $data['customer_id'] != $order->get_user_id() ) {
 				// Make sure customer exists.
 				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_customer_user', $data['customer_id'] );
@@ -597,7 +597,7 @@ class WC_API_Orders extends WC_API_Resource {
 			// Set order currency.
 			if ( isset( $data['currency'] ) ) {
 				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_order_currency', $data['currency'] );
@@ -841,7 +841,7 @@ class WC_API_Orders extends WC_API_Resource {
 			) );
 
 			if ( is_null( $result ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID provided is not associated with order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID provided is not associated with order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 		}
 
@@ -862,7 +862,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// product is always required
 		if ( ! isset( $item['product_id'] ) && ! isset( $item['sku'] ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID or SKU is required', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID or SKU is required', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// when updating, ensure product ID provided matches
@@ -872,7 +872,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item_variation_id = wc_get_order_item_meta( $item['id'], '_variation_id' );
 
 			if ( $item['product_id'] != $item_product_id && $item['product_id'] != $item_variation_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID provided does not match this line item', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID provided does not match this line item', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 		}
 
@@ -887,7 +887,7 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( isset( $item['variations'] ) && is_array( $item['variations'] ) ) {
 			foreach ( $item['variations'] as $key => $value ) {
 				if ( ! $key || ! $value ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_product_variation', __( 'The product variation is invalid', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_product_variation', __( 'The product variation is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 			$variation_id = $this->get_variation_id( wc_get_product( $product_id ), $item['variations'] );
@@ -897,17 +897,17 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// must be a valid WC_Product
 		if ( ! is_object( $product ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product', __( 'Product is invalid.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product', __( 'Product is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// quantity must be positive float
 		if ( isset( $item['quantity'] ) && floatval( $item['quantity'] ) <= 0 ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// quantity is required when creating
 		if ( $creating && ! isset( $item['quantity'] ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity is required.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity is required.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		if ( $creating ) {
@@ -950,7 +950,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item_id = $line_item->save();
 
 			if ( ! $item_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1026,14 +1026,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// total must be a positive float
 		if ( isset( $shipping['total'] ) && floatval( $shipping['total'] ) < 0 ) {
-			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		if ( 'create' === $action ) {
 
 			// method ID is required
 			if ( ! isset( $shipping['method_id'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_shipping_item', __( 'Shipping method ID is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_shipping_item', __( 'Shipping method ID is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$rate = new WC_Shipping_Rate( $shipping['method_id'], isset( $shipping['method_title'] ) ? $shipping['method_title'] : '', isset( $shipping['total'] ) ? floatval( $shipping['total'] ) : 0, array(), $shipping['method_id'] );
@@ -1060,7 +1060,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$shipping_id = $item->save();
 
 			if ( ! $shipping_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1080,7 +1080,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// fee title is required
 			if ( ! isset( $fee['title'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee title is required', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee title is required', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$item = new WC_Order_Item_Fee();
@@ -1091,7 +1091,7 @@ class WC_API_Orders extends WC_API_Resource {
 			// if taxable, tax class and total are required
 			if ( ! empty( $fee['taxable'] ) ) {
 				if ( ! isset( $fee['tax_class'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$item->set_tax_status( 'taxable' );
@@ -1131,7 +1131,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$fee_id = $item->save();
 
 			if ( ! $fee_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1149,14 +1149,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// coupon amount must be positive float
 		if ( isset( $coupon['amount'] ) && floatval( $coupon['amount'] ) < 0 ) {
-			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		if ( 'create' === $action ) {
 
 			// coupon code is required
 			if ( empty( $coupon['code'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$item = new WC_Order_Item_Coupon();
@@ -1182,7 +1182,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$coupon_id = $item->save();
 
 			if ( ! $coupon_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1249,13 +1249,13 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$order_note = array(
@@ -1282,14 +1282,14 @@ class WC_API_Orders extends WC_API_Resource {
 	public function create_order_note( $order_id, $data ) {
 		try {
 			if ( ! isset( $data['order_note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_note' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order_note' ), 400 );
 			}
 
 			$data = $data['order_note'];
 
 			// permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_note', __( 'You do not have permission to create order notes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_note', __( 'You do not have permission to create order notes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$order_id = $this->validate_request( $order_id, $this->post_type, 'edit' );
@@ -1304,7 +1304,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// note content is required
 			if ( ! isset( $data['note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note', __( 'Order note is required', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note', __( 'Order note is required', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$is_customer_note = ( isset( $data['customer_note'] ) && true === $data['customer_note'] );
@@ -1313,7 +1313,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$note_id = $order->add_order_note( $data['note'], $is_customer_note );
 
 			if ( ! $note_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			// HTTP 201 Created
@@ -1341,7 +1341,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order_note( $order_id, $id, $data ) {
 		try {
 			if ( ! isset( $data['order_note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_note' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order_note' ), 400 );
 			}
 
 			$data = $data['order_note'];
@@ -1359,19 +1359,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure note ID is valid
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure note ID is associated with given order
 			if ( $note->comment_post_ID != $order->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_order_note_data', $data, $note->comment_ID, $order->get_id(), $this );
@@ -1423,31 +1423,31 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure note ID is valid
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure note ID is associated with given order
 			if ( $note->comment_post_ID != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Force delete since trashed order notes could not be managed through comments list table
 			$result = wc_delete_order_note( $note->comment_ID );
 
 			if ( ! $result ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			do_action( 'woocommerce_api_delete_order_note', $note->comment_ID, $order_id, $this );
 
-			return array( 'message' => __( 'Permanently deleted order note', 'woocommerce' ) );
+			return array( 'message' => __( 'Permanently deleted order note', 'woocommerce-legacy-rest-api' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -1509,14 +1509,14 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$order  = wc_get_order( $order_id );
 			$refund = wc_get_order( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$line_items = array();
@@ -1576,29 +1576,29 @@ class WC_API_Orders extends WC_API_Resource {
 	public function create_order_refund( $order_id, $data, $api_refund = true ) {
 		try {
 			if ( ! isset( $data['order_refund'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order_refund' ), 400 );
 			}
 
 			$data = $data['order_refund'];
 
 			// Permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_refund', __( 'You do not have permission to create order refunds', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_refund', __( 'You do not have permission to create order refunds', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$order_id = absint( $order_id );
 
 			if ( empty( $order_id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_order_refund_data', $data, $order_id, $this );
 
 			// Refund amount is required
 			if ( ! isset( $data['amount'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			} elseif ( 0 > $data['amount'] ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount must be positive.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount must be positive.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data['order_id']  = $order_id;
@@ -1608,7 +1608,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$refund = wc_create_refund( $data );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			// Refund via API
@@ -1625,7 +1625,7 @@ class WC_API_Orders extends WC_API_Resource {
 					if ( is_wp_error( $result ) ) {
 						return $result;
 					} elseif ( ! $result ) {
-						throw new WC_API_Exception( 'woocommerce_api_create_order_refund_api_failed', __( 'An error occurred while attempting to create the refund using the payment gateway API.', 'woocommerce' ), 500 );
+						throw new WC_API_Exception( 'woocommerce_api_create_order_refund_api_failed', __( 'An error occurred while attempting to create the refund using the payment gateway API.', 'woocommerce-legacy-rest-api' ), 500 );
 					}
 				}
 			}
@@ -1655,7 +1655,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order_refund( $order_id, $id, $data ) {
 		try {
 			if ( ! isset( $data['order_refund'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order_refund' ), 400 );
 			}
 
 			$data = $data['order_refund'];
@@ -1671,19 +1671,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure order ID is valid
 			$refund = get_post( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure refund ID is associated with given order
 			if ( $refund->post_parent != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_order_refund_data', $data, $refund->ID, $order_id, $this );
@@ -1732,19 +1732,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure refund ID is valid
 			$refund = get_post( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure refund ID is associated with given order
 			if ( $refund->post_parent != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			wc_delete_shop_order_transients( $order_id );
@@ -1772,7 +1772,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['orders'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_orders_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'orders' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_orders_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'orders' ), 400 );
 			}
 
 			$data  = $data['orders'];
@@ -1780,7 +1780,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_orders_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_orders_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$orders = array();

--- a/includes/legacy/api/v2/class-wc-api-products.php
+++ b/includes/legacy/api/v2/class-wc-api-products.php
@@ -182,7 +182,7 @@ class WC_API_Products extends WC_API_Resource {
 	public function get_products_count( $type = null, $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'read_private_products' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $type ) ) {
@@ -211,21 +211,21 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product' ), 400 );
 			}
 
 			$data = $data['product'];
 
 			// Check permissions
 			if ( ! current_user_can( 'publish_products' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product', __( 'You do not have permission to create products', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product', __( 'You do not have permission to create products', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_product_data', $data, $this );
 
 			// Check if product title is specified
 			if ( ! isset( $data['title'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_title', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'title' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_title', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'title' ), 400 );
 			}
 
 			// Check product type
@@ -240,7 +240,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate the product type
 			if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
 			}
 
 			// Enable description html tags.
@@ -320,7 +320,7 @@ class WC_API_Products extends WC_API_Resource {
 	public function edit_product( $id, $data ) {
 		try {
 			if ( ! isset( $data['product'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product' ), 400 );
 			}
 
 			$data = $data['product'];
@@ -366,7 +366,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate the product type.
 			if ( isset( $data['type'] ) && ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
 			}
 
 			// Check for featured/gallery images, upload it and set it.
@@ -452,7 +452,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		if ( ! $result ) {
-			return new WP_Error( 'woocommerce_api_cannot_delete_product', sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), 'product' ), array( 'status' => 500 ) );
+			return new WP_Error( 'woocommerce_api_cannot_delete_product', sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), 'product' ), array( 'status' => 500 ) );
 		}
 
 		// Delete parent product transients.
@@ -461,11 +461,11 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		if ( $force ) {
-			return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), 'product' ) );
+			return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce-legacy-rest-api' ), 'product' ) );
 		} else {
 			$this->server->send_status( '202' );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product' ) );
 		}
 	}
 
@@ -557,7 +557,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_categories = array();
@@ -590,18 +590,18 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'Invalid product category ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'Invalid product category ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$term = get_term( $id, 'product_cat' );
 
 			if ( is_wp_error( $term ) || is_null( $term ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'A product category with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'A product category with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$term_id = intval( $term->term_id );
@@ -946,7 +946,7 @@ class WC_API_Products extends WC_API_Resource {
 				if ( ! empty( $new_sku ) ) {
 					$unique_sku = wc_product_has_unique_sku( $product->get_id(), $new_sku );
 					if ( ! $unique_sku ) {
-						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product.', 'woocommerce' ), 400 );
+						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product.', 'woocommerce-legacy-rest-api' ), 400 );
 					} else {
 						$product->set_sku( $new_sku );
 					}
@@ -1290,7 +1290,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Create initial name and status.
 			if ( ! $variation->get_slug() ) {
 				/* translators: 1: variation id 2: product name */
-				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation->get_id(), $product->get_name() ) );
+				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce-legacy-rest-api' ), $variation->get_id(), $product->get_name() ) );
 				$variation->set_status( isset( $data['visible'] ) && false === $data['visible'] ? 'private' : 'publish' );
 			}
 
@@ -1617,8 +1617,8 @@ class WC_API_Products extends WC_API_Resource {
 				'created_at' => $this->server->format_datetime( time() ), // Default to now.
 				'updated_at' => $this->server->format_datetime( time() ),
 				'src'        => wc_placeholder_img_src(),
-				'title'      => __( 'Placeholder', 'woocommerce' ),
-				'alt'        => __( 'Placeholder', 'woocommerce' ),
+				'title'      => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
+				'alt'        => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
 				'position'   => 0,
 			);
 		}
@@ -1838,7 +1838,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_attributes   = array();
@@ -1879,12 +1879,12 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'Invalid product attribute ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'Invalid product attribute ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$attribute = $wpdb->get_row( $wpdb->prepare( "
@@ -1894,7 +1894,7 @@ class WC_API_Products extends WC_API_Resource {
 			 ", $id ) );
 
 			if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$product_attribute = array(
@@ -1926,25 +1926,25 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	protected function validate_attribute_data( $name, $slug, $type, $order_by, $new_data = true ) {
 		if ( empty( $name ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'name' ), 400 );
 		}
 
 		if ( strlen( $slug ) > 28 ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		} elseif ( $new_data && taxonomy_exists( wc_attribute_taxonomy_name( $slug ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		}
 
 		// Validate the attribute type
 		if ( ! in_array( wc_clean( $type ), array_keys( wc_get_attribute_types() ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_type', sprintf( __( 'Invalid product attribute type - the product attribute type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_attribute_types() ) ) ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_type', sprintf( __( 'Invalid product attribute type - the product attribute type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_attribute_types() ) ) ), 400 );
 		}
 
 		// Validate the attribute order by
 		if ( ! in_array( wc_clean( $order_by ), array( 'menu_order', 'name', 'name_num', 'id' ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_order_by', sprintf( __( 'Invalid product attribute order_by type - the product attribute order_by type must be any of these: %s', 'woocommerce' ), implode( ', ', array( 'menu_order', 'name', 'name_num', 'id' ) ) ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_order_by', sprintf( __( 'Invalid product attribute order_by type - the product attribute order_by type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array( 'menu_order', 'name', 'name_num', 'id' ) ) ), 400 );
 		}
 
 		return true;
@@ -1964,14 +1964,14 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ), 400 );
 			}
 
 			$data = $data['product_attribute'];
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_product_attribute_data', $data, $this );
@@ -2048,7 +2048,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -2056,7 +2056,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data      = apply_filters( 'woocommerce_api_edit_product_attribute_data', $data, $this );
@@ -2102,7 +2102,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Checks for an error in the product creation
 			if ( false === $update ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_attribute', __( 'Could not edit the attribute', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_attribute', __( 'Could not edit the attribute', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			do_action( 'woocommerce_api_edit_product_attribute', $id, $data );
@@ -2132,7 +2132,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute', __( 'You do not have permission to delete product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute', __( 'You do not have permission to delete product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id = absint( $id );
@@ -2144,7 +2144,7 @@ class WC_API_Products extends WC_API_Resource {
 			 ", $id ) );
 
 			if ( is_null( $attribute_name ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$deleted = $wpdb->delete(
@@ -2154,7 +2154,7 @@ class WC_API_Products extends WC_API_Resource {
 			);
 
 			if ( false === $deleted ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute', __( 'Could not delete the attribute', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute', __( 'Could not delete the attribute', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name( $attribute_name );
@@ -2173,7 +2173,7 @@ class WC_API_Products extends WC_API_Resource {
 			delete_transient( 'wc_attribute_taxonomies' );
 			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -2196,7 +2196,7 @@ class WC_API_Products extends WC_API_Resource {
 			$id = wc_get_product_id_by_sku( $sku );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_sku', __( 'Invalid product SKU', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_sku', __( 'Invalid product SKU', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			return $this->get_product( $id, $fields );
@@ -2246,7 +2246,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['products'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_products_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'products' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_products_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'products' ), 400 );
 			}
 
 			$data  = $data['products'];
@@ -2254,7 +2254,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_products_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_products_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$products = array();

--- a/includes/legacy/api/v2/class-wc-api-reports.php
+++ b/includes/legacy/api/v2/class-wc-api-reports.php
@@ -319,7 +319,7 @@ class WC_API_Reports extends WC_API_Resource {
 
 		if ( ! current_user_can( 'view_woocommerce_reports' ) ) {
 
-			return new WP_Error( 'woocommerce_api_user_cannot_read_report', __( 'You do not have permission to read this report', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error( 'woocommerce_api_user_cannot_read_report', __( 'You do not have permission to read this report', 'woocommerce-legacy-rest-api' ), array( 'status' => 401 ) );
 
 		} else {
 

--- a/includes/legacy/api/v2/class-wc-api-resource.php
+++ b/includes/legacy/api/v2/class-wc-api-resource.php
@@ -91,7 +91,7 @@ class WC_API_Resource {
 
 		// Validate ID
 		if ( empty( $id ) ) {
-			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce-legacy-rest-api' ), $type ), array( 'status' => 404 ) );
 		}
 
 		// Only custom post types have per-post type/permission checks
@@ -100,7 +100,7 @@ class WC_API_Resource {
 			$post = get_post( $id );
 
 			if ( null === $post ) {
-				return new WP_Error( "woocommerce_api_no_{$resource_name}_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce' ), $resource_name, $id ), array( 'status' => 404 ) );
+				return new WP_Error( "woocommerce_api_no_{$resource_name}_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce-legacy-rest-api' ), $resource_name, $id ), array( 'status' => 404 ) );
 			}
 
 			// For checking permissions, product variations are the same as the product post type
@@ -108,7 +108,7 @@ class WC_API_Resource {
 
 			// Validate post type
 			if ( $type !== $post_type ) {
-				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce' ), $resource_name ), array( 'status' => 404 ) );
+				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 404 ) );
 			}
 
 			// Validate permissions
@@ -116,19 +116,19 @@ class WC_API_Resource {
 
 				case 'read':
 					if ( ! $this->is_readable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 
 				case 'edit':
 					if ( ! $this->is_editable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 
 				case 'delete':
 					if ( ! $this->is_deletable( $post ) ) {
-						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+						return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 					}
 					break;
 			}
@@ -369,9 +369,9 @@ class WC_API_Resource {
 			$result = wp_delete_user( $id );
 
 			if ( $result ) {
-				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
+				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce-legacy-rest-api' ) );
 			} else {
-				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 			}
 		} else {
 
@@ -379,15 +379,15 @@ class WC_API_Resource {
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 
 			if ( ! $result ) {
-				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 500 ) );
 			}
 
 			if ( $force ) {
-				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 			} else {
 				$this->server->send_status( '202' );
 
-				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 			}
 		}
 	}

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -161,7 +161,7 @@ class WC_API_Server {
 		} elseif ( ! is_wp_error( $user ) ) {
 
 			// WP_Errors are handled in serve_request()
-			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce' ), array( 'code' => 500 ) );
+			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce-legacy-rest-api' ), array( 'code' => 500 ) );
 
 		}
 
@@ -316,7 +316,7 @@ class WC_API_Server {
 				break;
 
 			default :
-				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 400 ) );
 		}
 
 		foreach ( $this->get_routes() as $route => $handlers ) {
@@ -335,7 +335,7 @@ class WC_API_Server {
 				}
 
 				if ( ! is_callable( $callback ) ) {
-					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce' ), array( 'status' => 500 ) );
+					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 				}
 
 				$args = array_merge( $args, $this->params['GET'] );
@@ -372,7 +372,7 @@ class WC_API_Server {
 			}
 		}
 
-		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce' ), array( 'status' => 404 ) );
+		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 	}
 
 	/**
@@ -427,7 +427,7 @@ class WC_API_Server {
 				$ordered_parameters[] = $param->getDefaultValue();
 			} else {
 				// We don't have this parameter and it wasn't optional, abort!
-				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param->getName() ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), $param->getName() ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/includes/legacy/api/v2/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v2/class-wc-api-webhooks.php
@@ -140,7 +140,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 	public function get_webhooks_count( $status = null, $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $status ) ) {
@@ -168,26 +168,26 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['webhook'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'webhook' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'webhook' ), 400 );
 			}
 
 			$data = $data['webhook'];
 
 			// permission check
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks.', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks.', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_webhook_data', $data, $this );
 
 			// validate topic
 			if ( empty( $data['topic'] ) || ! wc_is_webhook_valid_topic( strtolower( $data['topic'] ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// validate delivery URL
 			if ( empty( $data['delivery_url'] ) || ! wc_is_valid_url( $data['delivery_url'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$webhook_data = apply_filters( 'woocommerce_new_webhook_data', array(
@@ -196,7 +196,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 				'ping_status'   => 'closed',
 				'post_author'   => get_current_user_id(),
 				'post_password' => 'webhook_' . wp_generate_password(),
-				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce' ), (new DateTime('now'))->format( _x( 'M d, Y @ h:i A', 'Webhook created on date parsed by DateTime::format', 'woocommerce' ) ) ),
+				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce-legacy-rest-api' ), (new DateTime('now'))->format( _x( 'M d, Y @ h:i A', 'Webhook created on date parsed by DateTime::format', 'woocommerce-legacy-rest-api' ) ) ),
 			), $data, $this );
 
 			$webhook = new WC_Webhook();
@@ -239,7 +239,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['webhook'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'webhook' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'webhook' ), 400 );
 			}
 
 			$data = $data['webhook'];
@@ -262,7 +262,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 					$webhook->set_topic( $data['topic'] );
 
 				} else {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -273,7 +273,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 					$webhook->set_delivery_url( $data['delivery_url'] );
 
 				} else {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -438,7 +438,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$webhook = new WC_Webhook( $webhook_id );
@@ -446,7 +446,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 			$log = 0;
 
 			if ( ! $log ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			return array( 'webhook_delivery' => apply_filters( 'woocommerce_api_webhook_delivery_response', array(), $id, $fields, $log, $webhook_id, $this ) );
@@ -473,13 +473,13 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		// Validate ID.
 		if ( empty( $id ) ) {
-			return new WP_Error( "woocommerce_api_invalid_webhook_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_invalid_webhook_id", sprintf( __( 'Invalid %s ID', 'woocommerce-legacy-rest-api' ), $type ), array( 'status' => 404 ) );
 		}
 
 		$webhook = wc_get_webhook( $id );
 
 		if ( null === $webhook ) {
-			return new WP_Error( "woocommerce_api_no_webhook_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce' ), 'webhook', $id ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_no_webhook_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce-legacy-rest-api' ), 'webhook', $id ), array( 'status' => 404 ) );
 		}
 
 		// Validate permissions.
@@ -487,19 +487,19 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 			case 'read':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_read_webhook", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_read_webhook", sprintf( __( 'You do not have permission to read this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'edit':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_edit_webhook", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_edit_webhook", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'delete':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_delete_webhook", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_delete_webhook", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 		}

--- a/includes/legacy/api/v3/class-wc-api-authentication.php
+++ b/includes/legacy/api/v3/class-wc-api-authentication.php
@@ -80,7 +80,7 @@ class WC_API_Authentication {
 			$keys = $this->get_keys_by_consumer_key( $params['consumer_key'] );
 
 			if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $params['consumer_secret'] ) ) {
-				throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce' ), 401 );
+				throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			return $keys;
@@ -108,10 +108,10 @@ class WC_API_Authentication {
 	 * @since 2.4
 	 */
 	private function exit_with_unauthorized_headers() {
-		$auth_message = __( 'WooCommerce API. Use a consumer key in the username field and a consumer secret in the password field.', 'woocommerce' );
+		$auth_message = __( 'WooCommerce API. Use a consumer key in the username field and a consumer secret in the password field.', 'woocommerce-legacy-rest-api' );
 		header( 'WWW-Authenticate: Basic realm="' . $auth_message . '"' );
 		header( 'HTTP/1.0 401 Unauthorized' );
-		throw new Exception( __( 'Consumer Secret is invalid.', 'woocommerce' ), 401 );
+		throw new Exception( __( 'Consumer Secret is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 	}
 
 	/**
@@ -141,7 +141,7 @@ class WC_API_Authentication {
 		foreach ( $param_names as $param_name ) {
 
 			if ( empty( $params[ $param_name ] ) ) {
-				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce' ), $param_name ), 404 );
+				throw new Exception( sprintf( __( '%s parameter is missing', 'woocommerce-legacy-rest-api' ), $param_name ), 404 );
 			}
 		}
 
@@ -176,7 +176,7 @@ class WC_API_Authentication {
 		", $consumer_key ), ARRAY_A );
 
 		if ( empty( $keys ) ) {
-			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Consumer key is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $keys;
@@ -196,7 +196,7 @@ class WC_API_Authentication {
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! $user ) {
-			throw new Exception( __( 'API user is invalid', 'woocommerce' ), 401 );
+			throw new Exception( __( 'API user is invalid', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		return $user;
@@ -240,7 +240,7 @@ class WC_API_Authentication {
 
 		// Sort parameters
 		if ( ! uksort( $params, 'strcmp' ) ) {
-			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - failed to sort parameters.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		// Normalize parameter key/values
@@ -260,7 +260,7 @@ class WC_API_Authentication {
 		$string_to_sign = $http_method . '&' . $base_request_uri . '&' . $query_string;
 
 		if ( 'HMAC-SHA1' !== $params['oauth_signature_method'] && 'HMAC-SHA256' !== $params['oauth_signature_method'] ) {
-			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - signature method is invalid.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$hash_algorithm = strtolower( str_replace( 'HMAC-', '', $params['oauth_signature_method'] ) );
@@ -269,7 +269,7 @@ class WC_API_Authentication {
 		$signature = base64_encode( hash_hmac( $hash_algorithm, $string_to_sign, $secret, true ) );
 
 		if ( ! hash_equals( $signature, $consumer_signature ) ) {
-			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid signature - provided signature does not match.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 	}
 
@@ -334,7 +334,7 @@ class WC_API_Authentication {
 		$valid_window = 15 * 60; // 15 minute window
 
 		if ( ( $timestamp < time() - $valid_window ) || ( $timestamp > time() + $valid_window ) ) {
-			throw new Exception( __( 'Invalid timestamp.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid timestamp.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$used_nonces = maybe_unserialize( $keys['nonces'] );
@@ -344,7 +344,7 @@ class WC_API_Authentication {
 		}
 
 		if ( in_array( $nonce, $used_nonces ) ) {
-			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce' ), 401 );
+			throw new Exception( __( 'Invalid nonce - nonce has already been used.', 'woocommerce-legacy-rest-api' ), 401 );
 		}
 
 		$used_nonces[ $timestamp ] = $nonce;
@@ -379,7 +379,7 @@ class WC_API_Authentication {
 			case 'HEAD':
 			case 'GET':
 				if ( 'read' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have read permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 
@@ -388,7 +388,7 @@ class WC_API_Authentication {
 			case 'PATCH':
 			case 'DELETE':
 				if ( 'write' !== $key_permissions && 'read_write' !== $key_permissions ) {
-					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce' ), 401 );
+					throw new Exception( __( 'The API key provided does not have write permissions.', 'woocommerce-legacy-rest-api' ), 401 );
 				}
 				break;
 		}

--- a/includes/legacy/api/v3/class-wc-api-coupons.php
+++ b/includes/legacy/api/v3/class-wc-api-coupons.php
@@ -114,7 +114,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			$coupon = new WC_Coupon( $id );
 
 			if ( 0 === $coupon->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_id', __( 'Invalid coupon ID', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$coupon_data = array(
@@ -158,7 +158,7 @@ class WC_API_Coupons extends WC_API_Resource {
 	public function get_coupons_count( $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'read_private_shop_coupons' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_coupons_count', __( 'You do not have permission to read the coupons count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$query = $this->query_coupons( $filter );
@@ -184,7 +184,7 @@ class WC_API_Coupons extends WC_API_Resource {
 			$id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 1;", $code ) );
 
 			if ( is_null( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_code', __( 'Invalid coupon code', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			return $this->get_coupon( $id, $fields );
@@ -207,28 +207,28 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupon'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'coupon' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'coupon' ), 400 );
 			}
 
 			$data = $data['coupon'];
 
 			// Check user permission
 			if ( ! current_user_can( 'publish_shop_coupons' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_coupon', __( 'You do not have permission to create coupons', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_coupon', __( 'You do not have permission to create coupons', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_coupon_data', $data, $this );
 
 			// Check if coupon code is specified
 			if ( ! isset( $data['code'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_code', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'code' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_code', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'code' ), 400 );
 			}
 
 			$coupon_code  = wc_format_coupon_code( $data['code'] );
 			$id_from_code = wc_get_coupon_id_by_code( $coupon_code );
 
 			if ( $id_from_code ) {
-				throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$defaults = array(
@@ -256,7 +256,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 			// Validate coupon types
 			if ( ! in_array( wc_clean( $coupon_data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
 			}
 
 			$new_coupon = array(
@@ -319,7 +319,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupon'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'coupon' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupon_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'coupon' ), 400 );
 			}
 
 			$data = $data['coupon'];
@@ -339,13 +339,13 @@ class WC_API_Coupons extends WC_API_Resource {
 				$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $id );
 
 				if ( $id_from_code ) {
-					throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_coupon_code_already_exists', __( 'The coupon code already exists', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$updated = wp_update_post( array( 'ID' => intval( $id ), 'post_title' => $coupon_code ) );
 
 				if ( 0 === $updated ) {
-					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -353,14 +353,14 @@ class WC_API_Coupons extends WC_API_Resource {
 				$updated = wp_update_post( array( 'ID' => intval( $id ), 'post_excerpt' => $data['description'] ) );
 
 				if ( 0 === $updated ) {
-					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_cannot_update_coupon', __( 'Failed to update coupon', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
 			if ( isset( $data['type'] ) ) {
 				// Validate coupon types
 				if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_coupon_types() ) ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_coupon_type', sprintf( __( 'Invalid coupon type - the coupon type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_coupon_types() ) ) ), 400 );
 				}
 				update_post_meta( $id, 'discount_type', $data['type'] );
 			}
@@ -518,7 +518,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['coupons'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_coupons_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'coupons' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_coupons_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'coupons' ), 400 );
 			}
 
 			$data  = $data['coupons'];
@@ -526,7 +526,7 @@ class WC_API_Coupons extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_coupons_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_coupons_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$coupons = array();

--- a/includes/legacy/api/v3/class-wc-api-customers.php
+++ b/includes/legacy/api/v3/class-wc-api-customers.php
@@ -205,10 +205,10 @@ class WC_API_Customers extends WC_API_Resource {
 			if ( is_email( $email ) ) {
 				$customer = get_user_by( 'email', $email );
 				if ( ! is_object( $customer ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce' ), 404 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce-legacy-rest-api' ), 404 );
 				}
 			} else {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_email', __( 'Invalid customer email', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			return $this->get_customer( $customer->ID, $fields );
@@ -229,7 +229,7 @@ class WC_API_Customers extends WC_API_Resource {
 	public function get_customers_count( $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'list_users' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customers_count', __( 'You do not have permission to read the customers count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$query = $this->query_customers( $filter );
@@ -347,21 +347,21 @@ class WC_API_Customers extends WC_API_Resource {
 	public function create_customer( $data ) {
 		try {
 			if ( ! isset( $data['customer'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'customer' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'customer' ), 400 );
 			}
 
 			$data = $data['customer'];
 
 			// Checks with can create new users.
 			if ( ! current_user_can( 'create_users' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'You do not have permission to create this customer', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_customer_data', $data, $this );
 
 			// Checks with the email is missing.
 			if ( ! isset( $data['email'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_email', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'email' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_email', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'email' ), 400 );
 			}
 
 			// Create customer.
@@ -372,7 +372,7 @@ class WC_API_Customers extends WC_API_Resource {
 			$customer->save();
 
 			if ( ! $customer->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'This resource cannot be created.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_customer', __( 'This resource cannot be created.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Added customer data.
@@ -402,7 +402,7 @@ class WC_API_Customers extends WC_API_Resource {
 	public function edit_customer( $id, $data ) {
 		try {
 			if ( ! isset( $data['customer'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'customer' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customer_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'customer' ), 400 );
 			}
 
 			$data = $data['customer'];
@@ -706,14 +706,14 @@ class WC_API_Customers extends WC_API_Resource {
 
 			// validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Invalid customer ID', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// non-existent IDs return a valid WP_User object with the user ID = 0
 			$customer = new WP_User( $id );
 
 			if ( 0 === $customer->ID ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_customer', __( 'Invalid customer', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// validate permissions
@@ -721,19 +721,19 @@ class WC_API_Customers extends WC_API_Resource {
 
 				case 'read':
 					if ( ! current_user_can( 'list_users' ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_customer', __( 'You do not have permission to read this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 
 				case 'edit':
 					if ( ! wc_rest_check_user_permissions( 'edit', $customer->ID ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_customer', __( 'You do not have permission to edit this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 
 				case 'delete':
 					if ( ! wc_rest_check_user_permissions( 'delete', $customer->ID ) ) {
-						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce' ), 401 );
+						throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_customer', __( 'You do not have permission to delete this customer', 'woocommerce-legacy-rest-api' ), 401 );
 					}
 					break;
 			}
@@ -771,7 +771,7 @@ class WC_API_Customers extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['customers'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_customers_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'customers' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_customers_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'customers' ), 400 );
 			}
 
 			$data  = $data['customers'];
@@ -779,7 +779,7 @@ class WC_API_Customers extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_customers_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_customers_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$customers = array();

--- a/includes/legacy/api/v3/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v3/class-wc-api-json-handler.php
@@ -51,14 +51,14 @@ class WC_API_JSON_Handler implements WC_API_Handler {
 
 			if ( ! apply_filters( 'woocommerce_api_jsonp_enabled', true ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_disabled', 'message' => __( 'JSONP support is disabled on this site', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			$jsonp_callback = $_GET['_jsonp'];
 
 			if ( ! wp_check_jsonp_callback( $jsonp_callback ) ) {
 				WC()->api->server->send_status( 400 );
-				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce' ) ) ) );
+				return wp_json_encode( array( array( 'code' => 'woocommerce_api_jsonp_callback_invalid', __( 'The JSONP callback function is invalid', 'woocommerce-legacy-rest-api' ) ) ) );
 			}
 
 			WC()->api->server->header( 'X-Content-Type-Options', 'nosniff' );

--- a/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/includes/legacy/api/v3/class-wc-api-orders.php
@@ -333,7 +333,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! current_user_can( 'read_private_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_orders_count', __( 'You do not have permission to read the orders count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $status ) ) {
@@ -397,14 +397,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['order'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order' ), 400 );
 			}
 
 			$data = $data['order'];
 
 			// permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order', __( 'You do not have permission to create orders', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order', __( 'You do not have permission to create orders', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_order_data', $data, $this );
@@ -420,7 +420,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 				// make sure customer exists
 				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$default_order_args['customer_id'] = $data['customer_id'];
@@ -430,7 +430,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$order = $this->create_base_order( $default_order_args, $data );
 
 			if ( is_wp_error( $order ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce' ), implode( ', ', $order->get_error_messages() ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order', sprintf( __( 'Cannot create order: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', $order->get_error_messages() ) ), 400 );
 			}
 
 			// billing/shipping addresses
@@ -469,7 +469,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 				// method ID & title are required
 				if ( empty( $data['payment_details']['method_id'] ) || empty( $data['payment_details']['method_title'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_payment_details', __( 'Payment method ID and title are required', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_payment_details', __( 'Payment method ID and title are required', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_payment_method', $data['payment_details']['method_id'] );
@@ -485,7 +485,7 @@ class WC_API_Orders extends WC_API_Resource {
 			if ( isset( $data['currency'] ) ) {
 
 				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_order_currency', $data['currency'] );
@@ -539,7 +539,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order( $id, $data ) {
 		try {
 			if ( ! isset( $data['order'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order' ), 400 );
 			}
 
 			$data = $data['order'];
@@ -556,7 +556,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$order = wc_get_order( $id );
 
 			if ( empty( $order ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$order_args = array( 'order_id' => $order->get_id() );
@@ -570,7 +570,7 @@ class WC_API_Orders extends WC_API_Resource {
 			if ( isset( $data['customer_id'] ) && $data['customer_id'] != $order->get_user_id() ) {
 				// Make sure customer exists.
 				if ( false === get_user_by( 'id', $data['customer_id'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_customer_id', __( 'Customer ID is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_customer_user', $data['customer_id'] );
@@ -634,7 +634,7 @@ class WC_API_Orders extends WC_API_Resource {
 			// Set order currency.
 			if ( isset( $data['currency'] ) ) {
 				if ( ! array_key_exists( $data['currency'], get_woocommerce_currencies() ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_order_currency', __( 'Provided order currency is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				update_post_meta( $order->get_id(), '_order_currency', $data['currency'] );
@@ -885,7 +885,7 @@ class WC_API_Orders extends WC_API_Resource {
 			) );
 
 			if ( is_null( $result ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID provided is not associated with order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_item_id', __( 'Order item ID provided is not associated with order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 		}
 
@@ -906,7 +906,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// product is always required
 		if ( ! isset( $item['product_id'] ) && ! isset( $item['sku'] ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID or SKU is required', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID or SKU is required', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// when updating, ensure product ID provided matches
@@ -916,7 +916,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item_variation_id = wc_get_order_item_meta( $item['id'], '_variation_id' );
 
 			if ( $item['product_id'] != $item_product_id && $item['product_id'] != $item_variation_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID provided does not match this line item', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_id', __( 'Product ID provided does not match this line item', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 		}
 
@@ -931,7 +931,7 @@ class WC_API_Orders extends WC_API_Resource {
 		if ( isset( $item['variations'] ) && is_array( $item['variations'] ) ) {
 			foreach ( $item['variations'] as $key => $value ) {
 				if ( ! $key || ! $value ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_product_variation', __( 'The product variation is invalid', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_product_variation', __( 'The product variation is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 			$variation_id = $this->get_variation_id( wc_get_product( $product_id ), $item['variations'] );
@@ -941,17 +941,17 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// must be a valid WC_Product
 		if ( ! is_object( $product ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product', __( 'Product is invalid.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product', __( 'Product is invalid.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// quantity must be positive float
 		if ( isset( $item['quantity'] ) && floatval( $item['quantity'] ) <= 0 ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity must be a positive float.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// quantity is required when creating
 		if ( $creating && ! isset( $item['quantity'] ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity is required.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_quantity', __( 'Product quantity is required.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		// quantity
@@ -995,7 +995,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$item_id = $line_item->save();
 
 			if ( ! $item_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_create_line_item', __( 'Cannot create line item, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1071,14 +1071,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// total must be a positive float
 		if ( isset( $shipping['total'] ) && floatval( $shipping['total'] ) < 0 ) {
-			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_invalid_shipping_total', __( 'Shipping total must be a positive amount.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		if ( 'create' === $action ) {
 
 			// method ID is required
 			if ( ! isset( $shipping['method_id'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_shipping_item', __( 'Shipping method ID is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_shipping_item', __( 'Shipping method ID is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$rate = new WC_Shipping_Rate( $shipping['method_id'], isset( $shipping['method_title'] ) ? $shipping['method_title'] : '', isset( $shipping['total'] ) ? floatval( $shipping['total'] ) : 0, array(), $shipping['method_id'] );
@@ -1105,7 +1105,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$shipping_id = $item->save();
 
 			if ( ! $shipping_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_shipping', __( 'Cannot update shipping method, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1125,7 +1125,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// fee title is required
 			if ( ! isset( $fee['title'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee title is required', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee title is required', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$item = new WC_Order_Item_Fee();
@@ -1136,7 +1136,7 @@ class WC_API_Orders extends WC_API_Resource {
 			// if taxable, tax class and total are required
 			if ( ! empty( $fee['taxable'] ) ) {
 				if ( ! isset( $fee['tax_class'] ) ) {
-					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_invalid_fee_item', __( 'Fee tax class is required when fee is taxable.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 
 				$item->set_tax_status( 'taxable' );
@@ -1176,7 +1176,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$fee_id = $item->save();
 
 			if ( ! $fee_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_fee', __( 'Cannot update fee, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1194,14 +1194,14 @@ class WC_API_Orders extends WC_API_Resource {
 
 		// coupon amount must be positive float
 		if ( isset( $coupon['amount'] ) && floatval( $coupon['amount'] ) < 0 ) {
-			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount.', 'woocommerce' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_invalid_coupon_total', __( 'Coupon discount total must be a positive amount.', 'woocommerce-legacy-rest-api' ), 400 );
 		}
 
 		if ( 'create' === $action ) {
 
 			// coupon code is required
 			if ( empty( $coupon['code'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$item = new WC_Order_Item_Coupon();
@@ -1227,7 +1227,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$coupon_id = $item->save();
 
 			if ( ! $coupon_id ) {
-				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_cannot_update_order_coupon', __( 'Cannot update coupon, try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 		}
 	}
@@ -1294,13 +1294,13 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$order_note = array(
@@ -1327,14 +1327,14 @@ class WC_API_Orders extends WC_API_Resource {
 	public function create_order_note( $order_id, $data ) {
 		try {
 			if ( ! isset( $data['order_note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_note' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order_note' ), 400 );
 			}
 
 			$data = $data['order_note'];
 
 			// permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_note', __( 'You do not have permission to create order notes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_note', __( 'You do not have permission to create order notes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$order_id = $this->validate_request( $order_id, $this->post_type, 'edit' );
@@ -1349,7 +1349,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// note content is required
 			if ( ! isset( $data['note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note', __( 'Order note is required', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note', __( 'Order note is required', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$is_customer_note = ( isset( $data['customer_note'] ) && true === $data['customer_note'] );
@@ -1358,7 +1358,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$note_id = $order->add_order_note( $data['note'], $is_customer_note );
 
 			if ( ! $note_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			// HTTP 201 Created
@@ -1386,7 +1386,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order_note( $order_id, $id, $data ) {
 		try {
 			if ( ! isset( $data['order_note'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_note' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_note_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order_note' ), 400 );
 			}
 
 			$data = $data['order_note'];
@@ -1404,19 +1404,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure note ID is valid
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure note ID is associated with given order
 			if ( $note->comment_post_ID != $order->get_id() ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_order_note_data', $data, $note->comment_ID, $order->get_id(), $this );
@@ -1468,31 +1468,31 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'Invalid order note ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure note ID is valid
 			$note = get_comment( $id );
 
 			if ( is_null( $note ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'An order note with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure note ID is associated with given order
 			if ( $note->comment_post_ID != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_note_id', __( 'The order note ID provided is not associated with the order', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Force delete since trashed order notes could not be managed through comments list table
 			$result = wc_delete_order_note( $note->comment_ID );
 
 			if ( ! $result ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_order_note', __( 'This order note cannot be deleted', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			do_action( 'woocommerce_api_delete_order_note', $note->comment_ID, $order_id, $this );
 
-			return array( 'message' => __( 'Permanently deleted order note', 'woocommerce' ) );
+			return array( 'message' => __( 'Permanently deleted order note', 'woocommerce-legacy-rest-api' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -1554,14 +1554,14 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$order  = wc_get_order( $order_id );
 			$refund = wc_get_order( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$line_items = array();
@@ -1621,29 +1621,29 @@ class WC_API_Orders extends WC_API_Resource {
 	public function create_order_refund( $order_id, $data, $api_refund = true ) {
 		try {
 			if ( ! isset( $data['order_refund'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'order_refund' ), 400 );
 			}
 
 			$data = $data['order_refund'];
 
 			// Permission check
 			if ( ! current_user_can( 'publish_shop_orders' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_refund', __( 'You do not have permission to create order refunds', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_order_refund', __( 'You do not have permission to create order refunds', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$order_id = absint( $order_id );
 
 			if ( empty( $order_id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_id', __( 'Order ID is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_order_refund_data', $data, $order_id, $this );
 
 			// Refund amount is required
 			if ( ! isset( $data['amount'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount is required.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount is required.', 'woocommerce-legacy-rest-api' ), 400 );
 			} elseif ( 0 > $data['amount'] ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount must be positive.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund', __( 'Refund amount must be positive.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data['order_id']  = $order_id;
@@ -1653,7 +1653,7 @@ class WC_API_Orders extends WC_API_Resource {
 			$refund = wc_create_refund( $data );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce-legacy-rest-api' ), 500 );
 			}
 
 			// Refund via API
@@ -1670,7 +1670,7 @@ class WC_API_Orders extends WC_API_Resource {
 					if ( is_wp_error( $result ) ) {
 						return $result;
 					} elseif ( ! $result ) {
-						throw new WC_API_Exception( 'woocommerce_api_create_order_refund_api_failed', __( 'An error occurred while attempting to create the refund using the payment gateway API.', 'woocommerce' ), 500 );
+						throw new WC_API_Exception( 'woocommerce_api_create_order_refund_api_failed', __( 'An error occurred while attempting to create the refund using the payment gateway API.', 'woocommerce-legacy-rest-api' ), 500 );
 					}
 				}
 			}
@@ -1700,7 +1700,7 @@ class WC_API_Orders extends WC_API_Resource {
 	public function edit_order_refund( $order_id, $id, $data ) {
 		try {
 			if ( ! isset( $data['order_refund'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'order_refund' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_order_refund_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'order_refund' ), 400 );
 			}
 
 			$data = $data['order_refund'];
@@ -1716,19 +1716,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure order ID is valid
 			$refund = get_post( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure refund ID is associated with given order
 			if ( $refund->post_parent != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_order_refund_data', $data, $refund->ID, $order_id, $this );
@@ -1777,19 +1777,19 @@ class WC_API_Orders extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'Invalid order refund ID.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Ensure refund ID is valid
 			$refund = get_post( $id );
 
 			if ( ! $refund ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'An order refund with the provided ID could not be found.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			// Ensure refund ID is associated with given order
 			if ( $refund->post_parent != $order_id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_order_refund_id', __( 'The order refund ID provided is not associated with the order.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			wc_delete_shop_order_transients( $order_id );
@@ -1817,7 +1817,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['orders'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_orders_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'orders' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_orders_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'orders' ), 400 );
 			}
 
 			$data  = $data['orders'];
@@ -1825,7 +1825,7 @@ class WC_API_Orders extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_orders_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_orders_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$orders = array();

--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -231,7 +231,7 @@ class WC_API_Products extends WC_API_Resource {
 	public function get_products_count( $type = null, $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'read_private_products' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_products_count', __( 'You do not have permission to read the products count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $type ) ) {
@@ -260,21 +260,21 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product' ), 400 );
 			}
 
 			$data = $data['product'];
 
 			// Check permissions.
 			if ( ! current_user_can( 'publish_products' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product', __( 'You do not have permission to create products', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product', __( 'You do not have permission to create products', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_product_data', $data, $this );
 
 			// Check if product title is specified.
 			if ( ! isset( $data['title'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_title', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'title' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_title', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'title' ), 400 );
 			}
 
 			// Check product type.
@@ -289,7 +289,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate the product type.
 			if ( ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
 			}
 
 			// Enable description html tags.
@@ -374,7 +374,7 @@ class WC_API_Products extends WC_API_Resource {
 	public function edit_product( $id, $data ) {
 		try {
 			if ( ! isset( $data['product'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product' ), 400 );
 			}
 
 			$data = $data['product'];
@@ -420,7 +420,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate the product type.
 			if ( isset( $data['type'] ) && ! in_array( wc_clean( $data['type'] ), array_keys( wc_get_product_types() ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_type', sprintf( __( 'Invalid product type - the product type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_product_types() ) ) ), 400 );
 			}
 
 			// Menu order.
@@ -511,7 +511,7 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		if ( ! $result ) {
-			return new WP_Error( 'woocommerce_api_cannot_delete_product', sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), 'product' ), array( 'status' => 500 ) );
+			return new WP_Error( 'woocommerce_api_cannot_delete_product', sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), 'product' ), array( 'status' => 500 ) );
 		}
 
 		// Delete parent product transients.
@@ -520,11 +520,11 @@ class WC_API_Products extends WC_API_Resource {
 		}
 
 		if ( $force ) {
-			return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), 'product' ) );
+			return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce-legacy-rest-api' ), 'product' ) );
 		} else {
 			$this->server->send_status( '202' );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product' ) );
 		}
 	}
 
@@ -616,7 +616,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_categories = array();
@@ -649,18 +649,18 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'Invalid product category ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'Invalid product category ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_categories', __( 'You do not have permission to read product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$term = get_term( $id, 'product_cat' );
 
 			if ( is_wp_error( $term ) || is_null( $term ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'A product category with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_id', __( 'A product category with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$term_id = intval( $term->term_id );
@@ -704,12 +704,12 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_category'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_category_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_category' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_category_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_category' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_category', __( 'You do not have permission to create product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_category', __( 'You do not have permission to create product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$defaults = array(
@@ -729,7 +729,7 @@ class WC_API_Products extends WC_API_Resource {
 			if ( $data['parent'] ) {
 				$parent = get_term_by( 'id', $data['parent'], 'product_cat' );
 				if ( ! $parent ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_parent', __( 'Product category parent is invalid', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_product_category_parent', __( 'Product category parent is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -781,7 +781,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_category'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_category', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_category' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_category', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_category' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -789,7 +789,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_category', __( 'You do not have permission to edit product categories', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_category', __( 'You do not have permission to edit product categories', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data     = apply_filters( 'woocommerce_api_edit_product_category_data', $data, $this );
@@ -819,7 +819,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			$update = wp_update_term( $id, 'product_cat', $data );
 			if ( is_wp_error( $update ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_category', __( 'Could not edit the category', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_category', __( 'Could not edit the category', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			if ( ! empty( $data['display'] ) ) {
@@ -852,18 +852,18 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_category', __( 'You do not have permission to delete product category', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_category', __( 'You do not have permission to delete product category', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id      = absint( $id );
 			$deleted = wp_delete_term( $id, 'product_cat' );
 			if ( ! $deleted || is_wp_error( $deleted ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_category', __( 'Could not delete the category', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_category', __( 'Could not delete the category', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			do_action( 'woocommerce_api_delete_product_category', $id, $this );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_category' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_category' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -882,7 +882,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_tags', __( 'You do not have permission to read product tags', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_tags', __( 'You do not have permission to read product tags', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_tags = array();
@@ -915,18 +915,18 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_tag_id', __( 'Invalid product tag ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_tag_id', __( 'Invalid product tag ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_tags', __( 'You do not have permission to read product tags', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_tags', __( 'You do not have permission to read product tags', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$term = get_term( $id, 'product_tag' );
 
 			if ( is_wp_error( $term ) || is_null( $term ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_tag_id', __( 'A product tag with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_tag_id', __( 'A product tag with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$term_id = intval( $term->term_id );
@@ -956,12 +956,12 @@ class WC_API_Products extends WC_API_Resource {
 	public function create_product_tag( $data ) {
 		try {
 			if ( ! isset( $data['product_tag'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_tag_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_tag' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_tag_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_tag' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_tag', __( 'You do not have permission to create product tags', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_tag', __( 'You do not have permission to create product tags', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$defaults = array(
@@ -1001,7 +1001,7 @@ class WC_API_Products extends WC_API_Resource {
 	public function edit_product_tag( $id, $data ) {
 		try {
 			if ( ! isset( $data['product_tag'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_tag', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_tag' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_tag', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_tag' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -1009,7 +1009,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_tag', __( 'You do not have permission to edit product tags', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_tag', __( 'You do not have permission to edit product tags', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_product_tag_data', $data, $this );
@@ -1021,7 +1021,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			$update = wp_update_term( $id, 'product_tag', $data );
 			if ( is_wp_error( $update ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_tag', __( 'Could not edit the tag', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_tag', __( 'Could not edit the tag', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			do_action( 'woocommerce_api_edit_product_tag', $id, $data );
@@ -1044,18 +1044,18 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_tag', __( 'You do not have permission to delete product tag', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_tag', __( 'You do not have permission to delete product tag', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id      = absint( $id );
 			$deleted = wp_delete_term( $id, 'product_tag' );
 			if ( ! $deleted || is_wp_error( $deleted ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_tag', __( 'Could not delete the tag', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_tag', __( 'Could not delete the tag', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			do_action( 'woocommerce_api_delete_product_tag', $id, $this );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_tag' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_tag' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -1431,7 +1431,7 @@ class WC_API_Products extends WC_API_Resource {
 				if ( ! empty( $new_sku ) ) {
 					$unique_sku = wc_product_has_unique_sku( $product->get_id(), $new_sku );
 					if ( ! $unique_sku ) {
-						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product.', 'woocommerce' ), 400 );
+						throw new WC_API_Exception( 'woocommerce_api_product_sku_already_exists', __( 'The SKU already exists on another product.', 'woocommerce-legacy-rest-api' ), 400 );
 					} else {
 						$product->set_sku( $new_sku );
 					}
@@ -1780,7 +1780,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Create initial name and status.
 			if ( ! $variation->get_slug() ) {
 				/* translators: 1: variation id 2: product name */
-				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce' ), $variation->get_id(), $product->get_name() ) );
+				$variation->set_name( sprintf( __( 'Variation #%1$s of %2$s', 'woocommerce-legacy-rest-api' ), $variation->get_id(), $product->get_name() ) );
 				$variation->set_status( isset( $data['visible'] ) && false === $data['visible'] ? 'private' : 'publish' );
 			}
 
@@ -2116,8 +2116,8 @@ class WC_API_Products extends WC_API_Resource {
 				'created_at' => $this->server->format_datetime( time() ), // Default to now.
 				'updated_at' => $this->server->format_datetime( time() ),
 				'src'        => wc_placeholder_img_src(),
-				'title'      => __( 'Placeholder', 'woocommerce' ),
-				'alt'        => __( 'Placeholder', 'woocommerce' ),
+				'title'      => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
+				'alt'        => __( 'Placeholder', 'woocommerce-legacy-rest-api' ),
 				'position'   => 0,
 			);
 		}
@@ -2391,7 +2391,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_attributes   = array();
@@ -2432,12 +2432,12 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'Invalid product attribute ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'Invalid product attribute ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attributes', __( 'You do not have permission to read product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$attribute = $wpdb->get_row( $wpdb->prepare( "
@@ -2447,7 +2447,7 @@ class WC_API_Products extends WC_API_Resource {
 			 ", $id ) );
 
 			if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$product_attribute = array(
@@ -2479,25 +2479,25 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	protected function validate_attribute_data( $name, $slug, $type, $order_by, $new_data = true ) {
 		if ( empty( $name ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'name' ), 400 );
 		}
 
 		if ( strlen( $slug ) > 28 ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		} elseif ( $new_data && taxonomy_exists( wc_attribute_taxonomy_name( $slug ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), $slug ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce-legacy-rest-api' ), $slug ), 400 );
 		}
 
 		// Validate the attribute type
 		if ( ! in_array( wc_clean( $type ), array_keys( wc_get_attribute_types() ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_type', sprintf( __( 'Invalid product attribute type - the product attribute type must be any of these: %s', 'woocommerce' ), implode( ', ', array_keys( wc_get_attribute_types() ) ) ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_type', sprintf( __( 'Invalid product attribute type - the product attribute type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array_keys( wc_get_attribute_types() ) ) ), 400 );
 		}
 
 		// Validate the attribute order by
 		if ( ! in_array( wc_clean( $order_by ), array( 'menu_order', 'name', 'name_num', 'id' ) ) ) {
-			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_order_by', sprintf( __( 'Invalid product attribute order_by type - the product attribute order_by type must be any of these: %s', 'woocommerce' ), implode( ', ', array( 'menu_order', 'name', 'name_num', 'id' ) ) ), 400 );
+			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_order_by', sprintf( __( 'Invalid product attribute order_by type - the product attribute order_by type must be any of these: %s', 'woocommerce-legacy-rest-api' ), implode( ', ', array( 'menu_order', 'name', 'name_num', 'id' ) ) ), 400 );
 		}
 
 		return true;
@@ -2517,14 +2517,14 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ), 400 );
 			}
 
 			$data = $data['product_attribute'];
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_product_attribute_data', $data, $this );
@@ -2602,7 +2602,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_attribute' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -2610,7 +2610,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data      = apply_filters( 'woocommerce_api_edit_product_attribute_data', $data, $this );
@@ -2656,7 +2656,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Checks for an error in the product creation.
 			if ( false === $update ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_attribute', __( 'Could not edit the attribute', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_attribute', __( 'Could not edit the attribute', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			do_action( 'woocommerce_api_edit_product_attribute', $id, $data );
@@ -2687,7 +2687,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute', __( 'You do not have permission to delete product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute', __( 'You do not have permission to delete product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id = absint( $id );
@@ -2699,7 +2699,7 @@ class WC_API_Products extends WC_API_Resource {
 			 ", $id ) );
 
 			if ( is_null( $attribute_name ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$deleted = $wpdb->delete(
@@ -2709,7 +2709,7 @@ class WC_API_Products extends WC_API_Resource {
 			);
 
 			if ( false === $deleted ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute', __( 'Could not delete the attribute', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute', __( 'Could not delete the attribute', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name( $attribute_name );
@@ -2729,7 +2729,7 @@ class WC_API_Products extends WC_API_Resource {
 			delete_transient( 'wc_attribute_taxonomies' );
 			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -2749,14 +2749,14 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attribute_terms', __( 'You do not have permission to read product attribute terms', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attribute_terms', __( 'You do not have permission to read product attribute terms', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$attribute_id = absint( $attribute_id );
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$terms = get_terms( $taxonomy, array( 'hide_empty' => false ) );
@@ -2797,24 +2797,24 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Validate ID
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_term_id', __( 'Invalid product attribute ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_term_id', __( 'Invalid product attribute ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attribute_terms', __( 'You do not have permission to read product attribute terms', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attribute_terms', __( 'You do not have permission to read product attribute terms', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$term = get_term( $id, $taxonomy );
 
 			if ( is_wp_error( $term ) || is_null( $term ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_term_id', __( 'A product attribute term with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_term_id', __( 'A product attribute term with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$attribute_term = array(
@@ -2845,27 +2845,27 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute_term'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_attribute_term' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute_term' ), 400 );
 			}
 
 			$data = $data['product_attribute_term'];
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_attribute', __( 'You do not have permission to create product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_product_attribute_term_data', $data, $this );
 
 			// Check if attribute term name is specified.
 			if ( ! isset( $data['name'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_name', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'name' ), 400 );
 			}
 
 			$args = array();
@@ -2910,7 +2910,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_attribute_term'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_attribute_term' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_attribute_term' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -2918,13 +2918,13 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_attribute', __( 'You do not have permission to edit product attributes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_edit_product_attribute_term_data', $data, $this );
@@ -2971,27 +2971,27 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions.
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute_term', __( 'You do not have permission to delete product attribute terms', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_attribute_term', __( 'You do not have permission to delete product attribute terms', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_id', __( 'A product attribute with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$id   = absint( $id );
 			$term = wp_delete_term( $id, $taxonomy );
 
 			if ( ! $term ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute_term', sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), 'product_attribute_term' ), 500 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute_term', sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), 'product_attribute_term' ), 500 );
 			} elseif ( is_wp_error( $term ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_attribute_term', $term->get_error_message(), 400 );
 			}
 
 			do_action( 'woocommerce_api_delete_product_attribute_term', $id, $this );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -3038,7 +3038,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['products'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_products_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'products' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_products_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'products' ), 400 );
 			}
 
 			$data  = $data['products'];
@@ -3046,7 +3046,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_products_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_products_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$products = array();
@@ -3114,7 +3114,7 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_shipping_classes', __( 'You do not have permission to read product shipping classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_shipping_classes', __( 'You do not have permission to read product shipping classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$product_shipping_classes = array();
@@ -3144,18 +3144,18 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			$id = absint( $id );
 			if ( ! $id ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_id', __( 'Invalid product shipping class ID', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_id', __( 'Invalid product shipping class ID', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_shipping_classes', __( 'You do not have permission to read product shipping classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_shipping_classes', __( 'You do not have permission to read product shipping classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$term = get_term( $id, 'product_shipping_class' );
 
 			if ( is_wp_error( $term ) || is_null( $term ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_id', __( 'A product shipping class with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_id', __( 'A product shipping class with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$term_id = intval( $term->term_id );
@@ -3188,12 +3188,12 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_shipping_class'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_shipping_class_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_shipping_class' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_shipping_class_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'product_shipping_class' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_shipping_class', __( 'You do not have permission to create product shipping classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_product_shipping_class', __( 'You do not have permission to create product shipping classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$defaults = array(
@@ -3211,7 +3211,7 @@ class WC_API_Products extends WC_API_Resource {
 			if ( $data['parent'] ) {
 				$parent = get_term_by( 'id', $data['parent'], 'product_shipping_class' );
 				if ( ! $parent ) {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_parent', __( 'Product shipping class parent is invalid', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_product_shipping_class_parent', __( 'Product shipping class parent is invalid', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -3246,7 +3246,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['product_shipping_class'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_product_shipping_class', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'product_shipping_class' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_product_shipping_class', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'product_shipping_class' ), 400 );
 			}
 
 			$id   = absint( $id );
@@ -3254,7 +3254,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_shipping_class', __( 'You do not have permission to edit product shipping classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_product_shipping_class', __( 'You do not have permission to edit product shipping classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data           = apply_filters( 'woocommerce_api_edit_product_shipping_class_data', $data, $this );
@@ -3266,7 +3266,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			$update = wp_update_term( $id, 'product_shipping_class', $data );
 			if ( is_wp_error( $update ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_shipping_class', __( 'Could not edit the shipping class', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_shipping_class', __( 'Could not edit the shipping class', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			do_action( 'woocommerce_api_edit_product_shipping_class', $id, $data );
@@ -3291,18 +3291,18 @@ class WC_API_Products extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_product_terms' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_shipping_class', __( 'You do not have permission to delete product shipping classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_product_shipping_class', __( 'You do not have permission to delete product shipping classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id      = absint( $id );
 			$deleted = wp_delete_term( $id, 'product_shipping_class' );
 			if ( ! $deleted || is_wp_error( $deleted ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_shipping_class', __( 'Could not delete the shipping class', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_product_shipping_class', __( 'Could not delete the shipping class', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			do_action( 'woocommerce_api_delete_product_shipping_class', $id, $this );
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_shipping_class' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'product_shipping_class' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}

--- a/includes/legacy/api/v3/class-wc-api-reports.php
+++ b/includes/legacy/api/v3/class-wc-api-reports.php
@@ -323,7 +323,7 @@ class WC_API_Reports extends WC_API_Resource {
 
 		return new WP_Error(
 			'woocommerce_api_user_cannot_read_report',
-			__( 'You do not have permission to read this report', 'woocommerce' ),
+			__( 'You do not have permission to read this report', 'woocommerce-legacy-rest-api' ),
 			array( 'status' => 401 )
 		);
 	}

--- a/includes/legacy/api/v3/class-wc-api-resource.php
+++ b/includes/legacy/api/v3/class-wc-api-resource.php
@@ -93,7 +93,7 @@ class WC_API_Resource {
 
 		// Validate ID
 		if ( empty( $id ) ) {
-			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_invalid_{$resource_name}_id", sprintf( __( 'Invalid %s ID', 'woocommerce-legacy-rest-api' ), $type ), array( 'status' => 404 ) );
 		}
 
 		// Only custom post types have per-post type/permission checks
@@ -108,7 +108,7 @@ class WC_API_Resource {
 
 		if ( ! $is_invalid_orders_request ) {
 			if ( null === $post ) {
-				return new WP_Error( "woocommerce_api_no_{$resource_name}_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce' ), $resource_name, $id ), array( 'status' => 404 ) );
+				return new WP_Error( "woocommerce_api_no_{$resource_name}_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce-legacy-rest-api' ), $resource_name, $id ), array( 'status' => 404 ) );
 			}
 
 			// For checking permissions, product variations are the same as the product post type
@@ -116,7 +116,7 @@ class WC_API_Resource {
 
 			// Validate post type
 			if ( $type !== $post_type ) {
-				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce' ), $resource_name ), array( 'status' => 404 ) );
+				return new WP_Error( "woocommerce_api_invalid_{$resource_name}", sprintf( __( 'Invalid %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 404 ) );
 			}
 		}
 
@@ -125,19 +125,19 @@ class WC_API_Resource {
 
 			case 'read':
 				if ( $is_invalid_orders_request || ! $this->is_readable( $post ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_read_{$resource_name}", sprintf( __( 'You do not have permission to read this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'edit':
 				if ( $is_invalid_orders_request || ! $this->is_editable( $post ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_edit_{$resource_name}", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'delete':
 				if ( $is_invalid_orders_request || ! $this->is_deletable( $post ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), $resource_name ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_delete_{$resource_name}", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 401 ) );
 				}
 				break;
 		}
@@ -377,9 +377,9 @@ class WC_API_Resource {
 			$result = wp_delete_user( $id );
 
 			if ( $result ) {
-				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce' ) );
+				return array( 'message' => __( 'Permanently deleted customer', 'woocommerce-legacy-rest-api' ) );
 			} else {
-				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'woocommerce_api_cannot_delete_customer', __( 'The customer cannot be deleted', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 			}
 		} else {
 
@@ -387,17 +387,17 @@ class WC_API_Resource {
 			$result = ( $force ) ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 
 			if ( ! $result ) {
-				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce' ), $resource_name ), array( 'status' => 500 ) );
+				return new WP_Error( "woocommerce_api_cannot_delete_{$resource_name}", sprintf( __( 'This %s cannot be deleted', 'woocommerce-legacy-rest-api' ), $resource_name ), array( 'status' => 500 ) );
 			}
 
 			if ( $force ) {
-				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Permanently deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 
 			} else {
 
 				$this->server->send_status( '202' );
 
-				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), $resource_name ) );
+				return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), $resource_name ) );
 			}
 		}
 	}

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -161,7 +161,7 @@ class WC_API_Server {
 		} elseif ( ! is_wp_error( $user ) ) {
 
 			// WP_Errors are handled in serve_request()
-			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce' ), array( 'code' => 500 ) );
+			$user = new WP_Error( 'woocommerce_api_authentication_error', __( 'Invalid authentication method', 'woocommerce-legacy-rest-api' ), array( 'code' => 500 ) );
 
 		}
 
@@ -316,7 +316,7 @@ class WC_API_Server {
 				break;
 
 			default :
-				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_unsupported_method', __( 'Unsupported request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 400 ) );
 		}
 
 		foreach ( $this->get_routes() as $route => $handlers ) {
@@ -335,7 +335,7 @@ class WC_API_Server {
 				}
 
 				if ( ! is_callable( $callback ) ) {
-					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce' ), array( 'status' => 500 ) );
+					return new WP_Error( 'woocommerce_api_invalid_handler', __( 'The handler for the route is invalid', 'woocommerce-legacy-rest-api' ), array( 'status' => 500 ) );
 				}
 
 				$args = array_merge( $args, $this->params['GET'] );
@@ -372,7 +372,7 @@ class WC_API_Server {
 			}
 		}
 
-		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce' ), array( 'status' => 404 ) );
+		return new WP_Error( 'woocommerce_api_no_route', __( 'No route was found matching the URL and request method', 'woocommerce-legacy-rest-api' ), array( 'status' => 404 ) );
 	}
 
 	/**
@@ -428,7 +428,7 @@ class WC_API_Server {
 				$ordered_parameters[] = $param->getDefaultValue();
 			} else {
 				// We don't have this parameter and it wasn't optional, abort!
-				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce' ), $param->getName() ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_api_missing_callback_param', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), $param->getName() ), array( 'status' => 400 ) );
 			}
 		}
 

--- a/includes/legacy/api/v3/class-wc-api-taxes.php
+++ b/includes/legacy/api/v3/class-wc-api-taxes.php
@@ -125,14 +125,14 @@ class WC_API_Taxes extends WC_API_Resource {
 
 			// Permissions check
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax', __( 'You do not have permission to read tax rate', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax', __( 'You do not have permission to read tax rate', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			// Get tax rate details
 			$tax = WC_Tax::_get_tax_rate( $id );
 
 			if ( is_wp_error( $tax ) || empty( $tax ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_tax_id', __( 'A tax rate with the provided ID could not be found', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_tax_id', __( 'A tax rate with the provided ID could not be found', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$tax_data = array(
@@ -181,12 +181,12 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function create_tax( $data ) {
 		try {
 			if ( ! isset( $data['tax'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_tax_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'tax' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_tax_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'tax' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_tax', __( 'You do not have permission to create tax rates', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_tax', __( 'You do not have permission to create tax rates', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_tax_data', $data['tax'], $this );
@@ -251,12 +251,12 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function edit_tax( $id, $data ) {
 		try {
 			if ( ! isset( $data['tax'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_tax_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'tax' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_tax_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'tax' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_tax', __( 'You do not have permission to edit tax rates', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_edit_tax', __( 'You do not have permission to edit tax rates', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = $data['tax'];
@@ -340,7 +340,7 @@ class WC_API_Taxes extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_tax', __( 'You do not have permission to delete tax rates', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_tax', __( 'You do not have permission to delete tax rates', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$id = absint( $id );
@@ -348,10 +348,10 @@ class WC_API_Taxes extends WC_API_Resource {
 			WC_Tax::_delete_tax_rate( $id );
 
 			if ( 0 === $wpdb->rows_affected ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_tax', __( 'Could not delete the tax rate', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_tax', __( 'Could not delete the tax rate', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'tax' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'tax' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -370,7 +370,7 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function get_taxes_count( $class = null, $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_taxes_count', __( 'You do not have permission to read the taxes count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_taxes_count', __( 'You do not have permission to read the taxes count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $class ) ) {
@@ -454,7 +454,7 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function bulk( $data ) {
 		try {
 			if ( ! isset( $data['taxes'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_taxes_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce' ), 'taxes' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_taxes_data', sprintf( __( 'No %1$s data specified to create/edit %1$s', 'woocommerce-legacy-rest-api' ), 'taxes' ), 400 );
 			}
 
 			$data  = $data['taxes'];
@@ -462,7 +462,7 @@ class WC_API_Taxes extends WC_API_Resource {
 
 			// Limit bulk operation
 			if ( count( $data ) > $limit ) {
-				throw new WC_API_Exception( 'woocommerce_api_taxes_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce' ), $limit ), 413 );
+				throw new WC_API_Exception( 'woocommerce_api_taxes_request_entity_too_large', sprintf( __( 'Unable to accept more than %s items for this request.', 'woocommerce-legacy-rest-api' ), $limit ), 413 );
 			}
 
 			$taxes = array();
@@ -523,7 +523,7 @@ class WC_API_Taxes extends WC_API_Resource {
 		try {
 			// Permissions check
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax_classes', __( 'You do not have permission to read tax classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax_classes', __( 'You do not have permission to read tax classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$tax_classes = array();
@@ -531,7 +531,7 @@ class WC_API_Taxes extends WC_API_Resource {
 			// Add standard class
 			$tax_classes[] = array(
 				'slug' => 'standard',
-				'name' => __( 'Standard rate', 'woocommerce' ),
+				'name' => __( 'Standard rate', 'woocommerce-legacy-rest-api' ),
 			);
 
 			$classes = WC_Tax::get_tax_classes();
@@ -561,18 +561,18 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function create_tax_class( $data ) {
 		try {
 			if ( ! isset( $data['tax_class'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_tax_class_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'tax_class' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_tax_class_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'tax_class' ), 400 );
 			}
 
 			// Check permissions
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_tax_class', __( 'You do not have permission to create tax classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_tax_class', __( 'You do not have permission to create tax classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = $data['tax_class'];
 
 			if ( empty( $data['name'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_tax_class_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_tax_class_name', sprintf( __( 'Missing parameter %s', 'woocommerce-legacy-rest-api' ), 'name' ), 400 );
 			}
 
 			$name      = sanitize_text_field( $data['name'] );
@@ -609,7 +609,7 @@ class WC_API_Taxes extends WC_API_Resource {
 		try {
 			// Check permissions
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_tax_class', __( 'You do not have permission to delete tax classes', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_delete_tax_class', __( 'You do not have permission to delete tax classes', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$slug      = sanitize_title( $slug );
@@ -617,10 +617,10 @@ class WC_API_Taxes extends WC_API_Resource {
 			$deleted   = WC_Tax::delete_tax_class_by( 'slug', $slug );
 
 			if ( is_wp_error( $deleted ) || ! $deleted ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_tax_class', __( 'Could not delete the tax class', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_delete_tax_class', __( 'Could not delete the tax class', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
-			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'tax_class' ) );
+			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce-legacy-rest-api' ), 'tax_class' ) );
 		} catch ( WC_API_Exception $e ) {
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -636,7 +636,7 @@ class WC_API_Taxes extends WC_API_Resource {
 	public function get_tax_classes_count() {
 		try {
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax_classes_count', __( 'You do not have permission to read the tax classes count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_tax_classes_count', __( 'You do not have permission to read the tax classes count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$total = count( WC_Tax::get_tax_classes() ) + 1; // +1 for Standard Rate

--- a/includes/legacy/api/v3/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v3/class-wc-api-webhooks.php
@@ -140,7 +140,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 	public function get_webhooks_count( $status = null, $filter = array() ) {
 		try {
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_webhooks_count', __( 'You do not have permission to read the webhooks count', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			if ( ! empty( $status ) ) {
@@ -168,26 +168,26 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['webhook'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'webhook' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce-legacy-rest-api' ), 'webhook' ), 400 );
 			}
 
 			$data = $data['webhook'];
 
 			// permission check
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks.', 'woocommerce' ), 401 );
+				throw new WC_API_Exception( 'woocommerce_api_user_cannot_create_webhooks', __( 'You do not have permission to create webhooks.', 'woocommerce-legacy-rest-api' ), 401 );
 			}
 
 			$data = apply_filters( 'woocommerce_api_create_webhook_data', $data, $this );
 
 			// validate topic
 			if ( empty( $data['topic'] ) || ! wc_is_webhook_valid_topic( strtolower( $data['topic'] ) ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic is required and must be valid.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			// validate delivery URL
 			if ( empty( $data['delivery_url'] ) || ! wc_is_valid_url( $data['delivery_url'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			$webhook_data = apply_filters( 'woocommerce_new_webhook_data', array(
@@ -196,7 +196,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 				'ping_status'   => 'closed',
 				'post_author'   => get_current_user_id(),
 				'post_password' => 'webhook_' . wp_generate_password(),
-				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce' ), (new DateTime('now'))->format( _x( 'M d, Y @ h:i A', 'Webhook created on date parsed by DateTime::format', 'woocommerce' ) ) ),
+				'post_title'    => ! empty( $data['name'] ) ? $data['name'] : sprintf( __( 'Webhook created on %s', 'woocommerce-legacy-rest-api' ), (new DateTime('now'))->format( _x( 'M d, Y @ h:i A', 'Webhook created on date parsed by DateTime::format', 'woocommerce-legacy-rest-api' ) ) ),
 			), $data, $this );
 
 			$webhook = new WC_Webhook();
@@ -239,7 +239,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		try {
 			if ( ! isset( $data['webhook'] ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce' ), 'webhook' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_missing_webhook_data', sprintf( __( 'No %1$s data specified to edit %1$s', 'woocommerce-legacy-rest-api' ), 'webhook' ), 400 );
 			}
 
 			$data = $data['webhook'];
@@ -262,7 +262,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 					$webhook->set_topic( $data['topic'] );
 
 				} else {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid.', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_topic', __( 'Webhook topic must be valid.', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -273,7 +273,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 					$webhook->set_delivery_url( $data['delivery_url'] );
 
 				} else {
-					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce' ), 400 );
+					throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_url', __( 'Webhook delivery URL must be a valid URL starting with http:// or https://', 'woocommerce-legacy-rest-api' ), 400 );
 				}
 			}
 
@@ -438,7 +438,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 			$id = absint( $id );
 
 			if ( empty( $id ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID.', 'woocommerce' ), 404 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery ID.', 'woocommerce-legacy-rest-api' ), 404 );
 			}
 
 			$webhook = new WC_Webhook( $webhook_id );
@@ -446,7 +446,7 @@ class WC_API_Webhooks extends WC_API_Resource {
 			$log = 0;
 
 			if ( ! $log ) {
-				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery.', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_invalid_webhook_delivery_id', __( 'Invalid webhook delivery.', 'woocommerce-legacy-rest-api' ), 400 );
 			}
 
 			return array( 'webhook_delivery' => apply_filters( 'woocommerce_api_webhook_delivery_response', array(), $id, $fields, $log, $webhook_id, $this ) );
@@ -473,13 +473,13 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 		// Validate ID.
 		if ( empty( $id ) ) {
-			return new WP_Error( "woocommerce_api_invalid_webhook_id", sprintf( __( 'Invalid %s ID', 'woocommerce' ), $type ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_invalid_webhook_id", sprintf( __( 'Invalid %s ID', 'woocommerce-legacy-rest-api' ), $type ), array( 'status' => 404 ) );
 		}
 
 		$webhook = wc_get_webhook( $id );
 
 		if ( null === $webhook ) {
-			return new WP_Error( "woocommerce_api_no_webhook_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce' ), 'webhook', $id ), array( 'status' => 404 ) );
+			return new WP_Error( "woocommerce_api_no_webhook_found", sprintf( __( 'No %1$s found with the ID equal to %2$s', 'woocommerce-legacy-rest-api' ), 'webhook', $id ), array( 'status' => 404 ) );
 		}
 
 		// Validate permissions.
@@ -487,19 +487,19 @@ class WC_API_Webhooks extends WC_API_Resource {
 
 			case 'read':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_read_webhook", sprintf( __( 'You do not have permission to read this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_read_webhook", sprintf( __( 'You do not have permission to read this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'edit':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_edit_webhook", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_edit_webhook", sprintf( __( 'You do not have permission to edit this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 
 			case 'delete':
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					return new WP_Error( "woocommerce_api_user_cannot_delete_webhook", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce' ), 'webhook' ), array( 'status' => 401 ) );
+					return new WP_Error( "woocommerce_api_user_cannot_delete_webhook", sprintf( __( 'You do not have permission to delete this %s', 'woocommerce-legacy-rest-api' ), 'webhook' ), array( 'status' => 401 ) );
 				}
 				break;
 		}


### PR DESCRIPTION
The text domain for the translated text strings was still `'woocommerce'`, it has been updated to `'woocommerce-legacy-rest-api'` for coherency with the plugin name.

## Testing instructions

Test that the extension continues working as per the instructions in https://github.com/woocommerce/woocommerce-legacy-rest-api/pull/1, but try to force any error that results in a translatable string being returned (e.g. leave out the OAuth key).