### PR TITLE
Add sanitization for input data

### DIFF
--- a/includes/legacy/api/v1/class-wc-api-authentication.php
+++ b/includes/legacy/api/v1/class-wc-api-authentication.php
@@ -81,7 +81,7 @@ class WC_API_Authentication {
 		if ( ! empty( $_SERVER['PHP_AUTH_USER'] ) ) {
 
 			// Should be in HTTP Auth header by default
-			$consumer_key = $_SERVER['PHP_AUTH_USER'];
+			$consumer_key = sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) );
 
 		} elseif ( ! empty( $params['consumer_key'] ) ) {
 
@@ -97,7 +97,7 @@ class WC_API_Authentication {
 		if ( ! empty( $_SERVER['PHP_AUTH_PW'] ) ) {
 
 			// Should be in HTTP Auth header by default
-			$consumer_secret = $_SERVER['PHP_AUTH_PW'];
+			$consumer_secret = sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
 
 		} elseif ( ! empty( $params['consumer_secret'] ) ) {
 

--- a/includes/legacy/api/v1/class-wc-api-authentication.php
+++ b/includes/legacy/api/v1/class-wc-api-authentication.php
@@ -86,7 +86,7 @@ class WC_API_Authentication {
 		} elseif ( ! empty( $params['consumer_key'] ) ) {
 
 			// Allow a query string parameter as a fallback
-			$consumer_key = $params['consumer_key'];
+			$consumer_key = sanitize_key( wp_unslash( $params['consumer_key'] ) );
 
 		} else {
 
@@ -102,7 +102,7 @@ class WC_API_Authentication {
 		} elseif ( ! empty( $params['consumer_secret'] ) ) {
 
 			// Allow a query string parameter as a fallback
-			$consumer_secret = $params['consumer_secret'];
+			$consumer_secret = sanitize_key( wp_unslash( $params['consumer_secret'] ) );
 
 		} else {
 

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -132,7 +132,7 @@ class WC_API_Server {
 
 		// Compatibility for clients that can't use PUT/PATCH/DELETE
 		if ( isset( $_GET['_method'] ) ) {
-			$this->method = strtoupper( $_GET['_method'] );
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
 			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
 		}

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -117,14 +117,14 @@ class WC_API_Server {
 
 		if ( empty( $path ) ) {
 			if ( isset( $_SERVER['PATH_INFO'] ) ) {
-				$path = $_SERVER['PATH_INFO'];
+				$path = preg_replace( '~[^a-zA-Z0-9_/-]~', '', $_SERVER['PATH_INFO'] );
 			} else {
 				$path = '/';
 			}
 		}
 
 		$this->path           = $path;
-		$this->method         = $_SERVER['REQUEST_METHOD'];
+		$this->method         = strtoupper( sanitize_key( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
 		$this->params['GET']  = $_GET;
 		$this->params['POST'] = $_POST;
 		$this->headers        = $this->get_headers( $_SERVER );
@@ -134,7 +134,7 @@ class WC_API_Server {
 		if ( isset( $_GET['_method'] ) ) {
 			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
-			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) );
 		}
 
 		// determine type of request/response and load handler, JSON by default

--- a/includes/legacy/api/v2/class-wc-api-authentication.php
+++ b/includes/legacy/api/v2/class-wc-api-authentication.php
@@ -80,7 +80,7 @@ class WC_API_Authentication {
 		if ( ! empty( $_SERVER['PHP_AUTH_USER'] ) ) {
 
 			// Should be in HTTP Auth header by default
-			$consumer_key = $_SERVER['PHP_AUTH_USER'];
+			$consumer_key = sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) );
 
 		} elseif ( ! empty( $params['consumer_key'] ) ) {
 
@@ -96,7 +96,7 @@ class WC_API_Authentication {
 		if ( ! empty( $_SERVER['PHP_AUTH_PW'] ) ) {
 
 			// Should be in HTTP Auth header by default
-			$consumer_secret = $_SERVER['PHP_AUTH_PW'];
+			$consumer_secret = sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
 
 		} elseif ( ! empty( $params['consumer_secret'] ) ) {
 

--- a/includes/legacy/api/v2/class-wc-api-authentication.php
+++ b/includes/legacy/api/v2/class-wc-api-authentication.php
@@ -85,7 +85,7 @@ class WC_API_Authentication {
 		} elseif ( ! empty( $params['consumer_key'] ) ) {
 
 			// Allow a query string parameter as a fallback
-			$consumer_key = $params['consumer_key'];
+			$consumer_key = sanitize_key( wp_unslash( $params['consumer_key'] ) );
 
 		} else {
 
@@ -101,7 +101,7 @@ class WC_API_Authentication {
 		} elseif ( ! empty( $params['consumer_secret'] ) ) {
 
 			// Allow a query string parameter as a fallback
-			$consumer_secret = $params['consumer_secret'];
+			$consumer_secret = sanitize_key( wp_unslash( $params['consumer_secret'] ) );
 
 		} else {
 
@@ -149,11 +149,11 @@ class WC_API_Authentication {
 		}
 
 		// Fetch WP user by consumer key
-		$keys = $this->get_keys_by_consumer_key( $params['oauth_consumer_key'] );
+		$keys = $this->get_keys_by_consumer_key( sanitize_key( wp_unslash( $params['oauth_consumer_key'] ) ) );
 
 		// Perform OAuth validation
 		$this->check_oauth_signature( $keys, $params );
-		$this->check_oauth_timestamp_and_nonce( $keys, $params['oauth_timestamp'], $params['oauth_nonce'] );
+		$this->check_oauth_timestamp_and_nonce( $keys, sanitize_key( wp_unslash( $params['oauth_timestamp'] ) ), sanitize_key( wp_unslash( $params['oauth_nonce'] ) ) );
 
 		// Authentication successful, return user
 		return $keys;

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -131,7 +131,7 @@ class WC_API_Server {
 
 		// Compatibility for clients that can't use PUT/PATCH/DELETE
 		if ( isset( $_GET['_method'] ) ) {
-			$this->method = strtoupper( $_GET['_method'] );
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
 			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
 		}

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -116,14 +116,14 @@ class WC_API_Server {
 
 		if ( empty( $path ) ) {
 			if ( isset( $_SERVER['PATH_INFO'] ) ) {
-				$path = $_SERVER['PATH_INFO'];
+				$path = preg_replace( '~[^a-zA-Z0-9_/-]~', '', $_SERVER['PATH_INFO'] );
 			} else {
 				$path = '/';
 			}
 		}
 
 		$this->path           = $path;
-		$this->method         = $_SERVER['REQUEST_METHOD'];
+		$this->method         = strtoupper( sanitize_key( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
 		$this->params['GET']  = $_GET;
 		$this->params['POST'] = $_POST;
 		$this->headers        = $this->get_headers( $_SERVER );
@@ -133,7 +133,7 @@ class WC_API_Server {
 		if ( isset( $_GET['_method'] ) ) {
 			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
-			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) );
 		}
 
 		// load response handler

--- a/includes/legacy/api/v3/class-wc-api-authentication.php
+++ b/includes/legacy/api/v3/class-wc-api-authentication.php
@@ -91,9 +91,9 @@ class WC_API_Authentication {
 			$this->exit_with_unauthorized_headers();
 		}
 
-		$keys = $this->get_keys_by_consumer_key( $_SERVER['PHP_AUTH_USER'] );
+		$keys = $this->get_keys_by_consumer_key( sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) ) );
 
-		if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $_SERVER['PHP_AUTH_PW'] ) ) {
+		if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], sanitize_key( wp_unslash( $_SERVER['PHP_AUTH_PW'] ) ) ) ) {
 			$this->exit_with_unauthorized_headers();
 		}
 

--- a/includes/legacy/api/v3/class-wc-api-authentication.php
+++ b/includes/legacy/api/v3/class-wc-api-authentication.php
@@ -77,9 +77,9 @@ class WC_API_Authentication {
 
 		// if the $_GET parameters are present, use those first
 		if ( ! empty( $params['consumer_key'] ) && ! empty( $params['consumer_secret'] ) ) {
-			$keys = $this->get_keys_by_consumer_key( $params['consumer_key'] );
+			$keys = $this->get_keys_by_consumer_key( sanitize_key( wp_unslash( $params['consumer_key'] ) ) );
 
-			if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], $params['consumer_secret'] ) ) {
+			if ( ! $this->is_consumer_secret_valid( $keys['consumer_secret'], sanitize_key( wp_unslash( $params['consumer_secret'] ) ) ) ) {
 				throw new Exception( __( 'Consumer secret is invalid.', 'woocommerce' ), 401 );
 			}
 
@@ -146,11 +146,11 @@ class WC_API_Authentication {
 		}
 
 		// Fetch WP user by consumer key
-		$keys = $this->get_keys_by_consumer_key( $params['oauth_consumer_key'] );
+		$keys = $this->get_keys_by_consumer_key( sanitize_key( wp_unslash( $params['oauth_consumer_key'] ) ) );
 
 		// Perform OAuth validation
 		$this->check_oauth_signature( $keys, $params );
-		$this->check_oauth_timestamp_and_nonce( $keys, $params['oauth_timestamp'], $params['oauth_nonce'] );
+		$this->check_oauth_timestamp_and_nonce( $keys, sanitize_key( wp_unslash( $params['oauth_timestamp'] ) ), sanitize_key( wp_unslash( $params['oauth_nonce'] ) ) );
 
 		// Authentication successful, return user
 		return $keys;

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -131,7 +131,7 @@ class WC_API_Server {
 
 		// Compatibility for clients that can't use PUT/PATCH/DELETE
 		if ( isset( $_GET['_method'] ) ) {
-			$this->method = strtoupper( $_GET['_method'] );
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
 			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
 		}

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -116,14 +116,14 @@ class WC_API_Server {
 
 		if ( empty( $path ) ) {
 			if ( isset( $_SERVER['PATH_INFO'] ) ) {
-				$path = $_SERVER['PATH_INFO'];
+				$path = preg_replace( '~[^a-zA-Z0-9_/-]~', '', $_SERVER['PATH_INFO'] );
 			} else {
 				$path = '/';
 			}
 		}
 
 		$this->path           = $path;
-		$this->method         = $_SERVER['REQUEST_METHOD'];
+		$this->method         = strtoupper( sanitize_key( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) );
 		$this->params['GET']  = $_GET;
 		$this->params['POST'] = $_POST;
 		$this->headers        = $this->get_headers( $_SERVER );
@@ -133,7 +133,7 @@ class WC_API_Server {
 		if ( isset( $_GET['_method'] ) ) {
 			$this->method = strtoupper( sanitize_key( wp_unslash( $_GET['_method'] ) ) );
 		} elseif ( isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) {
-			$this->method = $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'];
+			$this->method = strtoupper( sanitize_key( wp_unslash( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) );
 		}
 
 		// load response handler

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -83,11 +83,11 @@ class WC_Legacy_API {
 		global $wp;
 
 		if ( ! empty( $_GET['wc-api-version'] ) ) {
-			$wp->query_vars['wc-api-version'] = $_GET['wc-api-version'];
+			$wp->query_vars['wc-api-version'] = sanitize_key( wp_unslash( $_GET['wc-api-version'] ) );
 		}
 
 		if ( ! empty( $_GET['wc-api-route'] ) ) {
-			$wp->query_vars['wc-api-route'] = $_GET['wc-api-route'];
+			$wp->query_vars['wc-api-route'] = preg_replace( '~[^a-zA-Z0-9_/-]~', '', $_GET['wc-api-route'] );
 		}
 
 		// REST API request.


### PR DESCRIPTION
Sanitization is added for all the input data received via `$_GET` and `$_SERVER` arrays, with the exception of `$_GET['_jsonp']` because these are already verified with `wp_check_jsonp_callback`.

## Testing instructions

Test that the extension continues working as per the instructions in https://github.com/woocommerce/woocommerce-legacy-rest-api/pull/1, but focusing in the following in particular:

1. Test a request that contains characters, numbers and at least one slash in the path, e.g. `orders/<order id>`.
1. Test with the regular OAuth authentication.
2. Test with basic authentication, passing the consumer key and secret as the user and password, respectively, as a HTTP header in the request: `Authorization: BASIC <base64 of key:secret>`.
3. Test with basic authentication, passing the consumer key and secret as query string arguments (`consumer_key` and `consumer_secret`, respectively).
4. Test supplying the request method in a `_method` key in the query string (e.g. issue a `POST` request to a GET endpoint with `?_method=GET` in the URL).
5. Test supplying the request method within a `X-HTTP-Method-Override` header in the request (e.g. issue a `POST` request to a GET endpoint with `X-HTTP-Method-Override: GET` added to the request headers).
6. Test with `v1`,  `v2` and `v3` endpoints.
7. Check if there's still any `$_GET` or `$_SERVER` variable that is still not sanitized. Keep in mind that the entire `$_GET` array is copied to a `$params` property in `class-wc-api-server.php`.

In order to test basic authentication you need to either use a SSL-enabled server or (probably easier) to temporarily tweak the code as follows: in the `authenticate` function in the `class-wc-api-authentication.php` files (there's one per API version) replace the line `if( is_ssl() ) {` with `if(true) {`.