### PR TITLE
Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS

### DIFF
--- a/includes/class-wc-legacy-rest-api-plugin.php
+++ b/includes/class-wc-legacy-rest-api-plugin.php
@@ -15,13 +15,19 @@ class WC_Legacy_REST_API_Plugin
     /**
      * Plugin initialization, to be invoked inside the woocommerce_init hook.
      */
-    private static function init() {
-        require_once __DIR__ . '/legacy/class-wc-legacy-api.php';
-        require_once __DIR__ . '/class-wc-api.php';
+    public static function on_woocommerce_init() {
+        if( ! self::legacy_api_still_in_woocommerce() ) {
+            require_once __DIR__ . '/legacy/class-wc-legacy-api.php';
+            require_once __DIR__ . '/class-wc-api.php';
 
-        WC()->api = new WC_API();
-        WC()->api->init();
-        WC()->api->add_endpoint();
+            WC()->api = new WC_API();
+            WC()->api->init();
+            WC()->api->add_endpoint();
+        }
+
+        if( ! self::maybe_add_hpos_incompatibility_admin_notice() ) {
+            self::maybe_remove_hpos_incompatibility_admin_notice();
+        }
     }
 
     /**
@@ -49,6 +55,10 @@ class WC_Legacy_REST_API_Plugin
      * Act on plugin activation.
      */
     public static function on_plugin_activated() {
+        if( ! self::woocommerce_is_active() ) {
+            return;
+        }
+        
         if( ! self::legacy_api_still_in_woocommerce() ) {
             require_once __DIR__ . '/legacy/class-wc-legacy-api.php';
             require_once __DIR__ . '/class-wc-api.php';
@@ -59,12 +69,55 @@ class WC_Legacy_REST_API_Plugin
     }
 
     /**
+     * Add the "legacy REST API and HPOS are incompatible" admin notice if needed.
+     * 
+     * @returns bool True if the notice has been added, false otherwise.
+     */
+    private static function maybe_add_hpos_incompatibility_admin_notice() {
+        if( 'yes' !== get_option( 'woocommerce_custom_orders_table_enabled' ) || self::user_has_dismissed_admin_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
+            return false;
+        }
+    
+        if ( ! WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
+            $features_page_url = admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
+            WC_Admin_Notices::add_custom_notice(
+                'legacy_rest_api_is_incompatible_with_hpos',
+                sprintf(
+                    wpautop( __( '⚠ <b>The Legacy REST API plugin and HPOS are both active on this site.</b><br/><br/>Please be aware that the WooCommerce Legacy REST API is <b>not</b> compatible with HPOS. <a target="_blank" href="%s">Manage features</a>', 'woocommerce-legacy-rest-api' ) ),
+                    $features_page_url
+                )
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove the "legacy REST API and HPOS are incompatible" admin notice if needed.
+     */
+    private static function maybe_remove_hpos_incompatibility_admin_notice() {
+        if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) && 'yes' !== get_option( 'woocommerce_custom_orders_table_enabled' ) ) {
+            self::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
+        }
+    }
+
+    /**
      * Act on plugin deactivation/uninstall.
      */
     public static function on_plugin_deactivated() {
+        if( ! self::woocommerce_is_active() ) {
+            return;
+        }
+
         if( ! self::legacy_api_still_in_woocommerce() ) {
             update_option( 'woocommerce_api_enabled', 'no' );
             flush_rewrite_rules();
+        }
+
+        if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
+            self::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
         }
     }
 
@@ -74,15 +127,6 @@ class WC_Legacy_REST_API_Plugin
     public static function on_before_woocommerce_init() {
         if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
             \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', self::$plugin_filename, false );
-        }
-    }
-
-     /**
-     * Handler for the before_woocommerce_init hook, needed to initialize the plugin.
-     */
-    public static function on_woocommerce_init() {
-        if( ! self::legacy_api_still_in_woocommerce() ) {
-            self::init();
         }
     }
 
@@ -100,5 +144,21 @@ class WC_Legacy_REST_API_Plugin
         $plugin_relative_path = str_replace( WP_PLUGIN_DIR . '/', '', self::$plugin_filename );
         $all_plugins[ $plugin_relative_path ][ 'Description' ] = 'The legacy WooCommerce REST API, which is now part of WooCommerce itself but will be removed in WooCommerce 9.0.';
         return $all_plugins;
+    }
+
+    /**
+     * Check if WooCommerce itself is active in the site.
+     */
+    private static function woocommerce_is_active() {
+        return class_exists( 'WooCommerce' );
+    }
+
+    /**
+     * Check if the current user has dismissed an admin notice.
+     * 
+     * @param string $notice_id Id of the notice.
+     */
+    private static function user_has_dismissed_admin_notice( $notice_id ) {
+        return '' !== get_user_meta( get_current_user_id(), "dismissed_${notice_id}_notice", true );
     }
 }

--- a/includes/class-wc-legacy-rest-api-plugin.php
+++ b/includes/class-wc-legacy-rest-api-plugin.php
@@ -74,7 +74,7 @@ class WC_Legacy_REST_API_Plugin
      * @returns bool True if the notice has been added, false otherwise.
      */
     private static function maybe_add_hpos_incompatibility_admin_notice() {
-        if( 'yes' !== get_option( 'woocommerce_custom_orders_table_enabled' ) || self::user_has_dismissed_admin_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
+        if( ! self::hpos_is_enabled() || self::user_has_dismissed_admin_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
             return false;
         }
     
@@ -95,10 +95,19 @@ class WC_Legacy_REST_API_Plugin
     }
 
     /**
+     * Check if HPOS is currently in use.
+     * 
+     * @returns bool True if HPOS is currently in use.
+     */
+    private function hpos_is_enabled(): bool {
+        return class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+    }
+
+    /**
      * Remove the "legacy REST API and HPOS are incompatible" admin notice if needed.
      */
     private static function maybe_remove_hpos_incompatibility_admin_notice() {
-        if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) && 'yes' !== get_option( 'woocommerce_custom_orders_table_enabled' ) ) {
+        if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) && ! self::hpos_is_enabled() ) {
             self::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
         }
     }

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -278,7 +278,7 @@ class WC_API_Server {
 
 		// Normalise the endpoints
 		foreach ( $endpoints as $route => &$handlers ) {
-			if ( count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
+			if ( is_array( $handlers ) && count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
 				$handlers = array( $handlers );
 			}
 		}

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -276,7 +276,7 @@ class WC_API_Server {
 
 		// Normalise the endpoints
 		foreach ( $endpoints as $route => &$handlers ) {
-			if ( count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
+			if ( is_array( $handlers ) && count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
 				$handlers = array( $handlers );
 			}
 		}

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -276,7 +276,7 @@ class WC_API_Server {
 
 		// Normalise the endpoints
 		foreach ( $endpoints as $route => &$handlers ) {
-			if ( count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
+			if ( is_array( $handlers ) && count( $handlers ) <= 2 && isset( $handlers[1] ) && ! is_array( $handlers[1] ) ) {
 				$handlers = array( $handlers );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woo, woocommerce, rest api
 Requires at least: 6.2
 Tested up to: 6.3
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -40,3 +40,10 @@ First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooC
 
 - Replace the text domain for human-readable strings from 'woocommerce' to 'woocommerce-legacy-rest-api'.
 - Add sanitization for data received via query string arguments and the $_SERVER array.
+
+
+= 1.0.2 2024-05-01
+
+Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS.
+The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page,
+and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.

--- a/woocommerce-legacy-rest-api.php
+++ b/woocommerce-legacy-rest-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Legacy REST API
  * Plugin URI: https://github.com/woocommerce/woocommerce-legacy-rest-api
  * Description: The legacy WooCommerce REST API, which used to be part of WooCommerce itself but is removed as of WooCommerce 9.0.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page, and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.

![image](https://github.com/woocommerce/woocommerce-legacy-rest-api/assets/937723/41451a7e-7df0-4772-8cb5-cf98450f3245)

## How to test

1. Start with the latest trunk of WooCommerce.
2. Make sure that the legacy REST API is disabled (WooCommerce - Settings - Advanced - Legacy API) and that HPOS is disabled (WooCommerce - Settings - Advanced - Features, select posts table as the orders data store).
3. Activate the plugin in the branch of this pull request. If you need a zip file for the plugin you can generate one checking out the branch of this pull request and running `git archive -o woocommerce-legacy-rest-api.zip HEAD`.
4. Verify that no admin notices appear.
5. Enable the legacy REST API and HPOS. Now the notice should appear.
6. Disable the legacy REST API. The notice will disappear.
7. Enable again the legacy REST API and disable HPOS. Again the notice isn't there.
8. Enable HPOS again. The notice is back.
9. Dismiss the notice. Verify that it doesn't appear again no matter what you do with the legacy REST API and HPOS settings.
10. Verify that the legacy REST API continues to function as usual, e.g. query `http://localhost/wc-api/v3/orders`.
11. Switch WooCommerce to the branch of https://github.com/woocommerce/woocommerce/pull/40627 and repeat the tests (note that now you can't disable the legacy REST API, so only test enabling and disabling HPOS).

Note: run this if you want to undo the notice dismissal:

```bash
 wp user meta delete <your user id> "dismissed_legacy_rest_api_is_incompatible_with_hpos_notice"
```