### PR TITLE
Fix: fatal error when checking if HPOS is enabled

### DIFF
--- a/includes/class-wc-legacy-rest-api-plugin.php
+++ b/includes/class-wc-legacy-rest-api-plugin.php
@@ -99,7 +99,7 @@ class WC_Legacy_REST_API_Plugin
      * 
      * @returns bool True if HPOS is currently in use.
      */
-    private function hpos_is_enabled(): bool {
+    private static function hpos_is_enabled(): bool {
         return class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -47,3 +47,8 @@ First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooC
 Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS.
 The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page,
 and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.
+
+
+= 1.0.3 2024-05-15
+
+Fix a bug introduced in 1.0.2 that caused a fatal error when checking if HPOS is enabled.

--- a/woocommerce-legacy-rest-api.php
+++ b/woocommerce-legacy-rest-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Legacy REST API
  * Plugin URI: https://github.com/woocommerce/woocommerce-legacy-rest-api
  * Description: The legacy WooCommerce REST API, which used to be part of WooCommerce itself but is removed as of WooCommerce 9.0.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
[v1.0.2](https://github.com/woocommerce/woocommerce-legacy-rest-api/pull/9) introduced a new `WC_Legacy_REST_API_Plugin::hpos_is_enabled` method, it's called as `self::hpos_is_enabled` but by mistake the method was not made static, which causes a fatal error. This pull request fixes this.

## How to test

Same testing instructions of https://github.com/woocommerce/woocommerce-legacy-rest-api/pull/9.