### PR TITLE
Update stable tag to 1.0.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woo, woocommerce, rest api
 Requires at least: 6.2
 Tested up to: 6.3
 Requires PHP: 7.4
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
Just update the stable tag to 1.0.3, this was missing from https://github.com/woocommerce/woocommerce-legacy-rest-api/pull/11.