### PR TITLE
Correct the logic that removes legacy API/HPOS compatibility notices.

### DIFF
--- a/includes/class-wc-legacy-rest-api-plugin.php
+++ b/includes/class-wc-legacy-rest-api-plugin.php
@@ -108,7 +108,7 @@ class WC_Legacy_REST_API_Plugin
      */
     private static function maybe_remove_hpos_incompatibility_admin_notice() {
         if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) && ! self::hpos_is_enabled() ) {
-            self::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
+            WC_Admin_Notices::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
         }
     }
 
@@ -126,7 +126,7 @@ class WC_Legacy_REST_API_Plugin
         }
 
         if ( WC_Admin_Notices::has_notice( 'legacy_rest_api_is_incompatible_with_hpos' ) ) {
-            self::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
+            WC_Admin_Notices::remove_notice( 'legacy_rest_api_is_incompatible_with_hpos' );
         }
     }
 

--- a/includes/class-wc-legacy-rest-api-plugin.php
+++ b/includes/class-wc-legacy-rest-api-plugin.php
@@ -168,6 +168,10 @@ class WC_Legacy_REST_API_Plugin
      * @param string $notice_id Id of the notice.
      */
     private static function user_has_dismissed_admin_notice( $notice_id ) {
-        return '' !== get_user_meta( get_current_user_id(), "dismissed_${notice_id}_notice", true );
+        if ( method_exists( 'WC_Admin_Notices', 'user_has_dismissed_notice' ) ) {
+            return WC_Admin_Notices::user_has_dismissed_notice( $notice_id );
+        } else {
+            return (bool) get_user_meta( get_current_user_id(), "dismissed_{$notice_id}_notice", true );
+        }
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -52,3 +52,7 @@ and will disappear when that ceases to be true. Once the notice is dismissed it 
 = 1.0.3 2024-05-15
 
 Fix a bug introduced in 1.0.2 that caused a fatal error when checking if HPOS is enabled.
+
+= 1.0.4 TBD =
+
+- Correct a problem in which the attempted removal of admin notices (warning of HPOS incompatibility) could lead to a fatal error during plugin deactivation.

--- a/readme.txt
+++ b/readme.txt
@@ -35,23 +35,20 @@ Note that since the Legacy REST API is not compatible with HPOS, once the plugin
 
 First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooCommerce 8.3.
 
-
 = 1.0.1 2024-01-08 =
 
 - Replace the text domain for human-readable strings from 'woocommerce' to 'woocommerce-legacy-rest-api'.
 - Add sanitization for data received via query string arguments and the $_SERVER array.
 
+= 1.0.2 2024-05-01 =
 
-= 1.0.2 2024-05-01
-
-Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS.
-The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page,
+- Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS.
+- The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page,
 and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.
 
+= 1.0.3 2024-05-15 =
 
-= 1.0.3 2024-05-15
-
-Fix a bug introduced in 1.0.2 that caused a fatal error when checking if HPOS is enabled.
+- Fix a bug introduced in 1.0.2 that caused a fatal error when checking if HPOS is enabled.
 
 = 1.0.4 TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -43,8 +43,7 @@ First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooC
 = 1.0.2 2024-05-01 =
 
 - Add a dismissable admin notice indicating that the Legacy REST API is not compatible with HPOS.
-- The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page,
-and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.
+- The notice will appear if the orders table is (or has been) selected as the orders data store in the WooCommerce features settings page, and will disappear when that ceases to be true. Once the notice is dismissed it will never appear again.
 
 = 1.0.3 2024-05-15 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,6 @@ First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooC
 
 - Fix a bug introduced in 1.0.2 that caused a fatal error when checking if HPOS is enabled.
 
-= 1.0.4 TBD =
+= 1.0.4 2024-05-16 =
 
 - Correct a problem in which the attempted removal of admin notices (warning of HPOS incompatibility) could lead to a fatal error during plugin deactivation.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woo, woocommerce, rest api
 Requires at least: 6.2
 Tested up to: 6.3
 Requires PHP: 7.4
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-legacy-rest-api.php
+++ b/woocommerce-legacy-rest-api.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Legacy REST API
  * Plugin URI: https://github.com/woocommerce/woocommerce-legacy-rest-api
  * Description: The legacy WooCommerce REST API, which used to be part of WooCommerce itself but is removed as of WooCommerce 9.0.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: WooCommerce
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
In some circumstances, deactivating the Legacy REST API plugin can lead to a fatal error [(see reports here)](https://wordpress.org/support/topic/1-0-3-is-not-a-solution/). The core problem seems to be our `remove_notice()` calls reference the wrong class.

<div align="center"><img width="700" alt="fatal-error" src="https://github.com/woocommerce/woocommerce-legacy-rest-api/assets/3594411/0c4bfeb2-3b16-4396-b870-f8b7281f02b9"></div>

---

### Steps to replicate

Although some of the reports we've received reference multisite networks, it is entirely possible to replicate the problem using a single site setup:

1. Install and activate WooCommerce.
2. Enable HPOS (though, if you start with a recent version of WooCommerce, it will probably already be active).
3. Install and activate the WooCommerce Legacy REST API plugin.
4. Deactivate it and a fatal error will occur, as in the above screenshot. However, I'm using Query Monitor, and so am provided with additional information: the error you see may contain less information.

---

### Testing instructions

1. Start with WooCommerce, and HPOS enabled.
2. If you are testing with a version of WooCommerce where https://github.com/woocommerce/woocommerce/pull/40627 hasn't been merged yet (so 8.9 or older, or a development version of 9.0) you need to explicitly enable the Legacy REST API (WooCommerce - Settings - Legacy API).
3. Install the WooCommerce Legacy REST API plugin.
4. You should now see a warning notice, as follows:

<div align="center"><img width="1750" alt="hpos-compat" src="https://github.com/woocommerce/woocommerce-legacy-rest-api/assets/3594411/960ba53a-5b64-45f2-a1b2-cf1afc2c9cda"></div>

5. Deactivate the plugin.
    - Before this change, you would encounter the fatal error documented in the PR's introduction.
    - With this change, there should be no fatal error and the above notice should be removed.

