### PR TITLE
Fix usage of woocommerce_new_order action

### DIFF
--- a/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/includes/legacy/api/v2/class-wc-api-orders.php
@@ -462,7 +462,7 @@ class WC_API_Orders extends WC_API_Resource {
 			wc_delete_shop_order_transients( $order );
 
 			do_action( 'woocommerce_api_create_order', $order->get_id(), $data, $this );
-			do_action( 'woocommerce_new_order', $order->get_id() );
+			do_action( 'woocommerce_new_order', $order->get_id(), $order );
 
 			return $this->get_order( $order->get_id() );
 		} catch ( WC_Data_Exception $e ) {

--- a/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/includes/legacy/api/v3/class-wc-api-orders.php
@@ -502,7 +502,7 @@ class WC_API_Orders extends WC_API_Resource {
 			wc_delete_shop_order_transients( $order );
 
 			do_action( 'woocommerce_api_create_order', $order->get_id(), $data, $this );
-			do_action( 'woocommerce_new_order', $order->get_id() );
+			do_action( 'woocommerce_new_order', $order->get_id(), $order );
 
 			return $this->get_order( $order->get_id() );
 		} catch ( WC_Data_Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -52,3 +52,7 @@ First version, replicates the WooCommerce Legacy REST API v3.1.0 present in WooC
 = 1.0.4 2024-05-16 =
 
 - Correct a problem in which the attempted removal of admin notices (warning of HPOS incompatibility) could lead to a fatal error during plugin deactivation.
+
+= 1.0.5 xxxx-xx-xx =
+
+- Fix the usage of woocommerce_new_order action hook to avoid a fatal errors.


### PR DESCRIPTION
See:
<img width="1725" alt="Screenshot 2024-11-08 at 11 36 45" src="https://github.com/user-attachments/assets/76f2cbc4-d35e-4c1c-9edd-f2ede7800bc5">

Usage of `woocommerce_new_order` action is wrong. It is missing a second required parameter (`$order`). Ref [here](https://github.com/search?q=repo%3Awoocommerce%2Fwoocommerce+%27woocommerce_new_order%27&type=code).

Related: 4741-gh-woocommerce/woocommerce-subscriptions

### Steps to replicate

You can replicate just by running unit tests using this PR (which uses the latest version of the plugin): 4741-gh-woocommerce/woocommerce-subscriptions

Or you can simulate any call to `create_order` (on v2 or v3).

### Testing instructions

Try to replicate the issue above on this branch. The problem should not happen anymore.